### PR TITLE
Allow MCP tasks to timeout and allow configuring MCP timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,17 +201,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -439,6 +432,7 @@ dependencies = [
 name = "dela"
 version = "0.0.6"
 dependencies = [
+ "chrono",
  "clap",
  "colored",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tracing-subscriber = "0.3.23"
 nix = { version = "0.31", features = ["signal"] }
 dirs = "6.0.0"
 shell-words = "1.1.1"
+chrono = { version = "0.4.42", default-features = false, features = ["clock", "std"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ $ dela mcp --init-claude-code  # Claude Code: ~/.claude-code/settings.json
 ```
 
 ### Starting the MCP Server Manually
+Assuming you have already run `dela init`.
 
 ```sh
 $ dela mcp [--cwd <directory>]
@@ -99,6 +100,7 @@ Tool names are stable, and `list_tasks` exposes a stable wire format (including 
 ### Security
 
 The MCP server uses the same allowlist as the CLI (`~/.config/dela/allowlist.toml`). Tasks must be explicitly allowlisted to be executed via MCP. Use the regular `dela` CLI commands to manage allowlists.
+`dela init` must be run before starting the MCP server so the dela config directory and allowlist exist.
 
 ## Frequently Asked Questions
 

--- a/dev_docs/mcp_design.md
+++ b/dev_docs/mcp_design.md
@@ -82,13 +82,13 @@ Libraries and their roles:
 ## Process & Output Model
 
 - **PID-centric**: Each started task is a real OS child process with a PID.
-- **First-second capture**: `task_start` collects stdout/stderr for up to **1 second** (configurable later).
+- **Default capture window**: `task_start` collects stdout/stderr for up to **1 second** by default.
   - If the child exits in ≤1s → return `{ state: "exited", exit_code, output }`.
   - If still running after 1s → background it and return `{ state: "running", pid, initial_output }`.
-- **Waited execution (planned)**: common agent workflows such as "run tests" benefit from a
-  bounded wait option. A future revision should allow `task_start(wait_for_exit_seconds=N)` or a
-  dedicated convenience tool that waits for short/medium tasks to finish and returns final status
-  plus an output tail in one round trip.
+- **Bounded wait execution**: callers can pass `task_start(wait_for_exit_seconds=N)` to extend
+  that wait window for short/medium tasks like tests and builds. If the task exits within the
+  requested window, `task_start` returns final status and captured output in one round trip. If it
+  is still running when the window expires, MCP backgrounds it and returns `running` with the PID.
 - **Output ring buffer**: Per-PID bounded buffer (default 1000 lines, 5 MB). `task_output` returns last N lines. Future paging via `from` byte cursor.
 - **Lifecycle**: `task_stop` sends SIGTERM, waits grace (default 5s), then SIGKILL. Background jobs are GC'd after a TTL (configurable).
 - **Real-time streaming**: Task output is streamed via MCP logging notifications. Clients can subscribe to `notifications/message` to receive output as it happens.
@@ -123,7 +123,7 @@ pub struct TaskStartArgs {
   pub args: Option<Vec<String>>, // optional arguments to pass to the task
   pub env: Option<HashMap<String, String>>, // optional environment variables
   pub cwd: Option<String>,      // optional working directory
-  pub wait_for_exit_seconds: Option<u64>, // future: wait for completion before backgrounding
+  pub wait_for_exit_seconds: Option<u64>, // optional bounded wait before backgrounding
 }
 
 #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
@@ -131,7 +131,7 @@ pub struct StartResultDto {
   pub state: String,            // "exited"|"running"|"failed"
   pub pid: Option<i32>,         // present if running
   pub exit_code: Option<i32>,   // present if exited/failed
-  pub initial_output: String,   // combined stdout+stderr captured during first-second
+  pub initial_output: String,   // combined stdout+stderr captured before returning
 }
 
 // Note: RunningTaskDto, TaskStatusArgs, TaskOutputArgs, TaskStopArgs are Phase 2
@@ -230,7 +230,7 @@ pub struct TaskOutputArgs {
   ]
 }
 ```
-**Future convenience option**
+**Bounded wait option**
 ```json
 {
   "unique_name": "tests-m",
@@ -406,7 +406,7 @@ Cursor-based paging lets clients fetch only new output instead of repeatedly re-
 
 These are not required for the minimal MCP surface, but they materially improve agent/editor UX:
 
-- **Bounded wait on start**: avoid poll loops for common commands like tests and builds.
+- **Bounded wait on start**: implemented via `task_start(wait_for_exit_seconds=...)` to avoid poll loops for common commands like tests and builds.
 - **Completion metadata in `task_status`**: include `exit_code` and `completed_at` for closed jobs.
 - **Incremental log paging**: add `from` cursors to `task_output` or `joblog://` resources.
 - **Discovery caching**: cache task discovery for hot paths such as repeated `list_tasks` calls.

--- a/dev_docs/mcp_design.md
+++ b/dev_docs/mcp_design.md
@@ -18,6 +18,11 @@ MCPI_NO_COLOR=1 RUST_LOG=warn npx @modelcontextprotocol/inspector ./target/relea
 **Protocol hygiene:** never print to **stdout** before/while serving MCP over stdio.
 All human/debug output must go to **stderr**. The server should enter
 `DelaMcpServer::serve_stdio()` and block until shutdown so the Inspector can establish the SSE session.
+
+**Transport note:** with the current `rmcp` stdio transport, dela speaks newline-delimited
+JSON-RPC messages over stdio, not `Content-Length` framed messages. Any local debugging
+client or smoke-test utility should write one JSON-RPC message per line and read one line
+per response/notification.
 ⸻
 
 # Dela MCP — Revised Design (First-Principles)
@@ -38,7 +43,7 @@ This redesign narrows each tool to a single, clear responsibility and aligns wit
   - description (optional)
 - **status** → Return a list of **all running tasks** (across all names) with PIDs and minimal status.
 - **task_start** → Start a task by **unique_name** with optional args/env/cwd. If it **finishes within 1s**, return its full output and exit status. If it **does not finish in 1s**, background it, return `running` with PID and any output captured during that first second.
-- **task_status** → Return status for **running instances of a given unique_name**. There may be multiple PIDs if the same task was started with different arguments.
+- **task_status** → Return status for instances of a given **unique_name**. There may be multiple PIDs if the same task was started with different arguments. Current wire format emphasizes state and elapsed time; future revisions should also expose completion metadata such as `exit_code` and `completed_at`.
 - **task_output** → Return the **last N lines** of output for a **PID** (with a default N). Supports simple paging via an optional `from` byte cursor (future).
 - **task_stop** → Stop a running task by **PID** (TERM with grace, then KILL on timeout).
 - 
@@ -57,7 +62,7 @@ cargo add schemars
 cargo add tracing tracing-subscriber
 
 Libraries and their roles:
-	•	rmcp - The core MCP protocol library. Handles stdio transport, tool routing, and logging notifications. We use it to define and expose our five tools via #[tool] attributes.
+	•	rmcp - The core MCP protocol library. Handles stdio transport, tool routing, and logging notifications. In our current stdio mode this means newline-delimited JSON-RPC messages over stdin/stdout. We use it to define and expose our five tools via #[tool] attributes.
 	•	tokio - Async runtime for Rust. Powers our job management with async process spawning, ring buffers, and graceful shutdown. The 'full' feature gives us process management and IO utilities.
 	•	serde/serde_json - Serialization framework for Rust. Handles all JSON encoding/decoding of our DTOs and tool parameters. The 'derive' feature lets us auto-generate serializers.
 	•	schemars - JSON Schema generation. Used with #[derive(JsonSchema)] to document our DTOs and tool parameters. Helps IDEs understand our protocol.
@@ -80,6 +85,10 @@ Libraries and their roles:
 - **First-second capture**: `task_start` collects stdout/stderr for up to **1 second** (configurable later).
   - If the child exits in ≤1s → return `{ state: "exited", exit_code, output }`.
   - If still running after 1s → background it and return `{ state: "running", pid, initial_output }`.
+- **Waited execution (planned)**: common agent workflows such as "run tests" benefit from a
+  bounded wait option. A future revision should allow `task_start(wait_for_exit_seconds=N)` or a
+  dedicated convenience tool that waits for short/medium tasks to finish and returns final status
+  plus an output tail in one round trip.
 - **Output ring buffer**: Per-PID bounded buffer (default 1000 lines, 5 MB). `task_output` returns last N lines. Future paging via `from` byte cursor.
 - **Lifecycle**: `task_stop` sends SIGTERM, waits grace (default 5s), then SIGKILL. Background jobs are GC'd after a TTL (configurable).
 - **Real-time streaming**: Task output is streamed via MCP logging notifications. Clients can subscribe to `notifications/message` to receive output as it happens.
@@ -114,6 +123,7 @@ pub struct TaskStartArgs {
   pub args: Option<Vec<String>>, // optional arguments to pass to the task
   pub env: Option<HashMap<String, String>>, // optional environment variables
   pub cwd: Option<String>,      // optional working directory
+  pub wait_for_exit_seconds: Option<u64>, // future: wait for completion before backgrounding
 }
 
 #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
@@ -126,6 +136,26 @@ pub struct StartResultDto {
 
 // Note: RunningTaskDto, TaskStatusArgs, TaskOutputArgs, TaskStopArgs are Phase 2
 // and not yet implemented in the current version.
+```
+
+Planned DTO enrichments for client ergonomics:
+
+```rust
+pub struct TaskStatusJobDto {
+  pub pid: i32,
+  pub unique_name: String,
+  pub state: String,               // "running"|"exited"|"failed"
+  pub elapsed_seconds: u64,
+  pub exit_code: Option<i32>,      // future
+  pub completed_at: Option<String> // future RFC3339 timestamp
+}
+
+pub struct TaskOutputArgs {
+  pub pid: u32,
+  pub lines: Option<usize>,
+  pub show_truncation: Option<bool>,
+  pub from: Option<u64>,           // future cursor for incremental paging
+}
 ```
 
 
@@ -200,6 +230,14 @@ pub struct StartResultDto {
   ]
 }
 ```
+**Future convenience option**
+```json
+{
+  "unique_name": "tests-m",
+  "wait_for_exit_seconds": 15
+}
+```
+This mode is intended for common agent flows where an extra `task_status` poll cycle is pure overhead.
 **Error (NotAllowlisted)**
 ```json
 {
@@ -310,11 +348,13 @@ All errors follow the JSON-RPC 2.0 error format:
   "content": [
     {
       "type": "text",
-      "text": "{\"jobs\": [{\"pid\": 12345, \"unique_name\": \"build-m\", \"state\": \"running\", \"elapsed_seconds\": 120}]}"
+      "text": "{\"jobs\": [{\"pid\": 12345, \"unique_name\": \"build-m\", \"state\": \"running\", \"elapsed_seconds\": 120, \"exit_code\": null, \"completed_at\": null}]}"
     }
   ]
 }
 ```
+`exit_code` and `completed_at` are planned enrichments that make polling clients simpler and remove
+the need to infer success/failure from logging notifications alone.
 
 ### 5) task_output
 **Args**
@@ -332,6 +372,11 @@ All errors follow the JSON-RPC 2.0 error format:
   ]
 }
 ```
+**Planned paging form**
+```json
+{ "pid": 12345, "from": 4096, "lines": 100 }
+```
+Cursor-based paging lets clients fetch only new output instead of repeatedly re-reading a tail and diffing it client-side.
 
 ### 6) task_stop
 **Args**
@@ -356,6 +401,20 @@ All errors follow the JSON-RPC 2.0 error format:
 - We can keep a conservative tool-only design. If needed for streaming or snapshots later:
   - `job://<pid>` → JSON status snapshot
   - `joblog://<pid>?from=<u64>` → chunked logs paging
+
+## Client Ergonomics Roadmap
+
+These are not required for the minimal MCP surface, but they materially improve agent/editor UX:
+
+- **Bounded wait on start**: avoid poll loops for common commands like tests and builds.
+- **Completion metadata in `task_status`**: include `exit_code` and `completed_at` for closed jobs.
+- **Incremental log paging**: add `from` cursors to `task_output` or `joblog://` resources.
+- **Discovery caching**: cache task discovery for hot paths such as repeated `list_tasks` calls.
+- **Workspace-aware editor config generation**: allow generated MCP configs to pre-bind `cwd`,
+  prefer absolute `dela` binary paths when useful, and reduce post-generation manual edits.
+- **Built-in MCP smoke test**: provide a small CLI workflow such as `dela mcp --self-test` or
+  `dela mcp --inspect-task <task>` for verifying transport, initialization, and task execution
+  without hand-crafting JSON-RPC.
 
 ⸻
 
@@ -402,16 +461,19 @@ impl ServerHandler for DelaMcpServer {
 - Checks runner availability
 - Captures output for first second, then backgrounds if still running
 - Returns `StartResultDto` with state, PID, exit code, and initial output
+- Future ergonomic extension: support bounded waiting for completion in the same call
 
 **task_status** - Returns status for running instances of a specific task
 - Filters jobs by unique_name
 - Returns all PIDs associated with that task name
 - Includes state (running/exited/failed), elapsed_seconds, command, and args
+- Planned enrichment: include `exit_code` and `completed_at` for completed jobs
 
 **task_output** - Returns the last N lines of output for a running task
 - Default 200 lines, configurable via `lines` parameter
 - Supports `show_truncation` flag to indicate if output was truncated
 - Per-PID ring buffer (1000 lines, 5MB max)
+- Planned enrichment: support cursor-based paging via `from`
 
 **task_stop** - Stops a running task by PID
 - Sends SIGTERM with configurable grace period (default 5s)
@@ -459,6 +521,11 @@ impl ServerHandler for DelaMcpServer {
 dela mcp [--cwd <dir>]
 ```
 Starts stdio server in `<dir>` (default `.`).
+
+Planned convenience entry points:
+- `dela mcp --self-test`
+- `dela mcp --inspect-task <unique_name>`
+- `dela mcp --init-<editor> --cwd <workspace>` for workspace-aware config generation
 
 ⸻
 

--- a/dev_docs/mcp_design.md
+++ b/dev_docs/mcp_design.md
@@ -310,7 +310,7 @@ All errors follow the JSON-RPC 2.0 error format:
   "content": [
     {
       "type": "text",
-      "text": "{\"jobs\": [{\"pid\": 12345, \"unique_name\": \"build-m\", \"state\": \"running\", \"started_at\": 120}]}"
+      "text": "{\"jobs\": [{\"pid\": 12345, \"unique_name\": \"build-m\", \"state\": \"running\", \"elapsed_seconds\": 120}]}"
     }
   ]
 }
@@ -406,7 +406,7 @@ impl ServerHandler for DelaMcpServer {
 **task_status** - Returns status for running instances of a specific task
 - Filters jobs by unique_name
 - Returns all PIDs associated with that task name
-- Includes state (running/exited/failed), started_at, command, and args
+- Includes state (running/exited/failed), elapsed_seconds, command, and args
 
 **task_output** - Returns the last N lines of output for a running task
 - Default 200 lines, configurable via `lines` parameter
@@ -429,7 +429,7 @@ impl ServerHandler for DelaMcpServer {
 - Per-PID ring buffer (VecDeque) with configurable limits:
   - Max 1000 lines per job
   - Max 5MB output per job
-- Job metadata includes: started_at, command, unique_name, source_name, args, cwd, file_path
+- Job metadata includes: started_at (internal), elapsed_seconds (wire), command, unique_name, source_name, args, cwd, file_path
 - Background monitoring task updates job state on child exit
 - Jobs transition through states: Running → Exited(exit_code) or Failed(reason)
 

--- a/dev_docs/mcp_design.md
+++ b/dev_docs/mcp_design.md
@@ -43,7 +43,7 @@ This redesign narrows each tool to a single, clear responsibility and aligns wit
   - description (optional)
 - **status** → Return a list of **all running tasks** (across all names) with PIDs and minimal status.
 - **task_start** → Start a task by **unique_name** with optional args/env/cwd. If it **finishes within 1s**, return its full output and exit status. If it **does not finish in 1s**, background it, return `running` with PID and any output captured during that first second.
-- **task_status** → Return status for instances of a given **unique_name**. There may be multiple PIDs if the same task was started with different arguments. Current wire format emphasizes state and elapsed time; future revisions should also expose completion metadata such as `exit_code` and `completed_at`.
+- **task_status** → Return status for instances of a given **unique_name**. There may be multiple PIDs if the same task was started with different arguments. The wire format includes state, elapsed time, and completion metadata (`exit_code`, `completed_at`) so clients do not need to infer outcomes from notifications alone.
 - **task_output** → Return the **last N lines** of output for a **PID** (with a default N). Supports simple paging via an optional `from` byte cursor (future).
 - **task_stop** → Stop a running task by **PID** (TERM with grace, then KILL on timeout).
 - 
@@ -146,8 +146,8 @@ pub struct TaskStatusJobDto {
   pub unique_name: String,
   pub state: String,               // "running"|"exited"|"failed"
   pub elapsed_seconds: u64,
-  pub exit_code: Option<i32>,      // future
-  pub completed_at: Option<String> // future RFC3339 timestamp
+  pub exit_code: Option<i32>,
+  pub completed_at: Option<String> // RFC3339 timestamp for completed jobs
 }
 
 pub struct TaskOutputArgs {
@@ -353,8 +353,8 @@ All errors follow the JSON-RPC 2.0 error format:
   ]
 }
 ```
-`exit_code` and `completed_at` are planned enrichments that make polling clients simpler and remove
-the need to infer success/failure from logging notifications alone.
+`exit_code` is populated for exited jobs, and `completed_at` is populated for exited/failed jobs so
+polling clients can determine completion without depending on logging notifications alone.
 
 ### 5) task_output
 **Args**
@@ -407,7 +407,7 @@ Cursor-based paging lets clients fetch only new output instead of repeatedly re-
 These are not required for the minimal MCP surface, but they materially improve agent/editor UX:
 
 - **Bounded wait on start**: implemented via `task_start(wait_for_exit_seconds=...)` to avoid poll loops for common commands like tests and builds.
-- **Completion metadata in `task_status`**: include `exit_code` and `completed_at` for closed jobs.
+- **Completion metadata in `task_status`**: implemented so clients can read `exit_code` and `completed_at` directly from polling responses.
 - **Incremental log paging**: add `from` cursors to `task_output` or `joblog://` resources.
 - **Discovery caching**: cache task discovery for hot paths such as repeated `list_tasks` calls.
 - **Workspace-aware editor config generation**: allow generated MCP configs to pre-bind `cwd`,
@@ -466,8 +466,7 @@ impl ServerHandler for DelaMcpServer {
 **task_status** - Returns status for running instances of a specific task
 - Filters jobs by unique_name
 - Returns all PIDs associated with that task name
-- Includes state (running/exited/failed), elapsed_seconds, command, and args
-- Planned enrichment: include `exit_code` and `completed_at` for completed jobs
+- Includes state (running/exited/failed), elapsed_seconds, command, args, `exit_code`, and `completed_at`
 
 **task_output** - Returns the last N lines of output for a running task
 - Default 200 lines, configurable via `lines` parameter
@@ -491,7 +490,7 @@ impl ServerHandler for DelaMcpServer {
 - Per-PID ring buffer (VecDeque) with configurable limits:
   - Max 1000 lines per job
   - Max 5MB output per job
-- Job metadata includes: started_at (internal), elapsed_seconds (wire), command, unique_name, source_name, args, cwd, file_path
+- Job metadata includes: started_at (internal), elapsed_seconds (wire), completed_at (wire for finished jobs), command, unique_name, source_name, args, cwd, file_path
 - Background monitoring task updates job state on child exit
 - Jobs transition through states: Running → Exited(exit_code) or Failed(reason)
 

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -320,7 +320,7 @@ Advanced MCP features for better editor integration and real-time feedback.
 **Medium Priority:**
 - [ ] **[DTKT-182]** **Environment introspection** - expose detected task runners and their versions
 - [x] **[DTKT-183]** **Task metadata caching** - cache discovered tasks to speed up repeated `list_tasks` calls and other hot-path MCP discovery calls
-- [ ] **[DTKT-191]** **Structured MCP task execution plans** - stop relying on shell-fragment command strings for MCP execution so compound runners like CMake can execute safely without `sh -c`
+- [x] **[DTKT-191]** **Disable CMake for MCP execution** - CMake is the known shell-fragment corner case (`cmake -S . -B build && cmake --build build --target <task>`). Rather than adding structured multi-step execution right now, MCP now reports CMake tasks as non-runnable and rejects `task_start` for them with an explicit unsupported-via-MCP hint.
 - [ ] **[DTKT-192]** **Robust editor config generation** - support JSONC-aware merges, optionally write absolute `dela` binary paths for GUI editor MCP configs, and add workspace-aware `cwd` generation modes
 - [ ] **[DTKT-193]** **Bounded wait execution** - add `task_start(wait_for_exit_seconds=...)` or equivalent convenience flow for short/medium tasks like tests and builds
 - [ ] **[DTKT-194]** **Completion metadata in task_status** - include `exit_code` and `completed_at` for completed jobs so clients do not need to infer outcomes from notifications

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -322,7 +322,7 @@ Advanced MCP features for better editor integration and real-time feedback.
 - [x] **[DTKT-183]** **Task metadata caching** - cache discovered tasks to speed up repeated `list_tasks` calls and other hot-path MCP discovery calls
 - [x] **[DTKT-191]** **Disable CMake for MCP execution** - CMake is the known shell-fragment corner case (`cmake -S . -B build && cmake --build build --target <task>`). Rather than adding structured multi-step execution right now, MCP now reports CMake tasks as non-runnable and rejects `task_start` for them with an explicit unsupported-via-MCP hint.
 - [ ] **[DTKT-192]** **Robust editor config generation** - support JSONC-aware merges, optionally write absolute `dela` binary paths for GUI editor MCP configs, and add workspace-aware `cwd` generation modes
-- [ ] **[DTKT-193]** **Bounded wait execution** - add `task_start(wait_for_exit_seconds=...)` or equivalent convenience flow for short/medium tasks like tests and builds
+- [x] **[DTKT-193]** **Bounded wait execution** - `task_start` now accepts `wait_for_exit_seconds`, extending the default 1-second wait window for short/medium tasks like tests and builds before falling back to background execution
 - [ ] **[DTKT-194]** **Completion metadata in task_status** - include `exit_code` and `completed_at` for completed jobs so clients do not need to infer outcomes from notifications
 - [ ] **[DTKT-195]** **Cursor-based log paging** - support `task_output(from=...)` or equivalent incremental log fetches
 - [ ] **[DTKT-196]** **MCP smoke test CLI** - provide `dela mcp --self-test` and/or `dela mcp --inspect-task <task>` for local MCP debugging without hand-written JSON-RPC

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -319,9 +319,13 @@ Advanced MCP features for better editor integration and real-time feedback.
 
 **Medium Priority:**
 - [ ] **[DTKT-182]** **Environment introspection** - expose detected task runners and their versions
-- [ ] **[DTKT-183]** **Task metadata caching** - cache discovered tasks to speed up repeated `list_tasks` calls
+- [ ] **[DTKT-183]** **Task metadata caching** - cache discovered tasks to speed up repeated `list_tasks` calls and other hot-path MCP discovery calls
 - [ ] **[DTKT-191]** **Structured MCP task execution plans** - stop relying on shell-fragment command strings for MCP execution so compound runners like CMake can execute safely without `sh -c`
-- [ ] **[DTKT-192]** **Robust editor config generation** - support JSONC-aware merges and optionally write absolute `dela` binary paths for GUI editor MCP configs
+- [ ] **[DTKT-192]** **Robust editor config generation** - support JSONC-aware merges, optionally write absolute `dela` binary paths for GUI editor MCP configs, and add workspace-aware `cwd` generation modes
+- [ ] **[DTKT-193]** **Bounded wait execution** - add `task_start(wait_for_exit_seconds=...)` or equivalent convenience flow for short/medium tasks like tests and builds
+- [ ] **[DTKT-194]** **Completion metadata in task_status** - include `exit_code` and `completed_at` for completed jobs so clients do not need to infer outcomes from notifications
+- [ ] **[DTKT-195]** **Cursor-based log paging** - support `task_output(from=...)` or equivalent incremental log fetches
+- [ ] **[DTKT-196]** **MCP smoke test CLI** - provide `dela mcp --self-test` and/or `dela mcp --inspect-task <task>` for local MCP debugging without hand-written JSON-RPC
 
 **Lower Priority:**
 - [ ] **[DTKT-178]** MCP **Resources** `job://<pid>` for job state snapshots, `joblog://<pid>?from=…` for log paging

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -323,7 +323,7 @@ Advanced MCP features for better editor integration and real-time feedback.
 - [x] **[DTKT-191]** **Disable CMake for MCP execution** - CMake is the known shell-fragment corner case (`cmake -S . -B build && cmake --build build --target <task>`). Rather than adding structured multi-step execution right now, MCP now reports CMake tasks as non-runnable and rejects `task_start` for them with an explicit unsupported-via-MCP hint.
 - [ ] **[DTKT-192]** **Robust editor config generation** - support JSONC-aware merges, optionally write absolute `dela` binary paths for GUI editor MCP configs, and add workspace-aware `cwd` generation modes
 - [x] **[DTKT-193]** **Bounded wait execution** - `task_start` now accepts `wait_for_exit_seconds`, extending the default 1-second wait window for short/medium tasks like tests and builds before falling back to background execution
-- [ ] **[DTKT-194]** **Completion metadata in task_status** - include `exit_code` and `completed_at` for completed jobs so clients do not need to infer outcomes from notifications
+- [x] **[DTKT-194]** **Completion metadata in task_status** - `task_status` now includes `exit_code` for exited jobs and `completed_at` for exited/failed jobs so clients do not need to infer outcomes from notifications
 - [ ] **[DTKT-195]** **Cursor-based log paging** - support `task_output(from=...)` or equivalent incremental log fetches
 - [ ] **[DTKT-196]** **MCP smoke test CLI** - provide `dela mcp --self-test` and/or `dela mcp --inspect-task <task>` for local MCP debugging without hand-written JSON-RPC
 

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -320,6 +320,8 @@ Advanced MCP features for better editor integration and real-time feedback.
 **Medium Priority:**
 - [ ] **[DTKT-182]** **Environment introspection** - expose detected task runners and their versions
 - [ ] **[DTKT-183]** **Task metadata caching** - cache discovered tasks to speed up repeated `list_tasks` calls
+- [ ] **[DTKT-191]** **Structured MCP task execution plans** - stop relying on shell-fragment command strings for MCP execution so compound runners like CMake can execute safely without `sh -c`
+- [ ] **[DTKT-192]** **Robust editor config generation** - support JSONC-aware merges and optionally write absolute `dela` binary paths for GUI editor MCP configs
 
 **Lower Priority:**
 - [ ] **[DTKT-178]** MCP **Resources** `job://<pid>` for job state snapshots, `joblog://<pid>?from=…` for log paging

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -319,7 +319,7 @@ Advanced MCP features for better editor integration and real-time feedback.
 
 **Medium Priority:**
 - [ ] **[DTKT-182]** **Environment introspection** - expose detected task runners and their versions
-- [ ] **[DTKT-183]** **Task metadata caching** - cache discovered tasks to speed up repeated `list_tasks` calls and other hot-path MCP discovery calls
+- [x] **[DTKT-183]** **Task metadata caching** - cache discovered tasks to speed up repeated `list_tasks` calls and other hot-path MCP discovery calls
 - [ ] **[DTKT-191]** **Structured MCP task execution plans** - stop relying on shell-fragment command strings for MCP execution so compound runners like CMake can execute safely without `sh -c`
 - [ ] **[DTKT-192]** **Robust editor config generation** - support JSONC-aware merges, optionally write absolute `dela` binary paths for GUI editor MCP configs, and add workspace-aware `cwd` generation modes
 - [ ] **[DTKT-193]** **Bounded wait execution** - add `task_start(wait_for_exit_seconds=...)` or equivalent convenience flow for short/medium tasks like tests and builds

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -276,6 +276,16 @@ pub async fn execute(
         return Ok(());
     }
 
+    crate::allowlist::load_allowlist().map_err(|e| {
+        crate::mcp::DelaError::mcp_not_ready(format!(
+            "MCP server cannot start because dela configuration is unavailable: {}",
+            e
+        ))
+        .to_error_data()
+        .message
+        .into_owned()
+    })?;
+
     // Start the MCP server
     mcp::run_stdio_server(root_path)
         .await

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -1,4 +1,4 @@
-use crate::runner::is_runner_available;
+use crate::runner::{is_runner_available, is_runner_available_for_mcp};
 use crate::types::Task;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -76,7 +76,7 @@ impl TaskDto {
             source_name: task.source_name.clone(),
             runner: task.runner.short_name().to_string(),
             command: task.runner.get_command(task),
-            runner_available: is_runner_available(&task.runner),
+            runner_available: is_runner_available_for_mcp(&task.runner),
             allowlisted: allowlist_evaluator.is_task_allowed(task).unwrap_or(false),
             file_path: task.file_path.to_string_lossy().to_string(),
             description: task.description.clone(),
@@ -544,6 +544,34 @@ mod tests {
             "# Travis CI task 'test' - not executable locally"
         );
         assert_eq!(dto.runner_available, false); // Travis CI is never available locally
+    }
+
+    #[test]
+    fn test_taskdto_cmake_not_available_for_mcp() {
+        use crate::mcp::allowlist::McpAllowlistEvaluator;
+
+        let task = Task {
+            name: "build-all".to_string(),
+            file_path: PathBuf::from("/project/CMakeLists.txt"),
+            definition_type: TaskDefinitionType::CMake,
+            runner: TaskRunner::CMake,
+            source_name: "build-all".to_string(),
+            description: Some("Build all targets".to_string()),
+            shadowed_by: None,
+            disambiguated_name: None,
+        };
+
+        let allowlist_evaluator = McpAllowlistEvaluator {
+            allowlist: crate::types::Allowlist::default(),
+        };
+
+        let dto = TaskDto::from_task_enriched(&task, &allowlist_evaluator);
+
+        assert_eq!(
+            dto.command,
+            "cmake -S . -B build && cmake --build build --target build-all"
+        );
+        assert!(!dto.runner_available);
     }
 }
 

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -593,7 +593,8 @@ pub struct TaskStartArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
 
-    /// Optional bounded wait in seconds before backgrounding the task
+    /// Optional bounded wait in seconds before backgrounding the task.
+    /// Defaults to 1 second when omitted. Allowed range: 0-3600 seconds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wait_for_exit_seconds: Option<u64>,
 }

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -592,6 +592,10 @@ pub struct TaskStartArgs {
     /// Optional working directory (if None, uses server's root directory)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+
+    /// Optional bounded wait in seconds before backgrounding the task
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wait_for_exit_seconds: Option<u64>,
 }
 
 /// Result of starting a task
@@ -608,7 +612,7 @@ pub struct StartResultDto {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
 
-    /// Combined stdout and stderr captured during the first second
+    /// Combined stdout and stderr captured before returning
     pub initial_output: String,
 }
 
@@ -643,4 +647,40 @@ pub struct TaskStopArgs {
     /// Grace period in seconds before sending SIGKILL (default: 5)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grace_period: Option<u64>,
+}
+
+#[cfg(test)]
+mod task_start_args_tests {
+    use super::TaskStartArgs;
+
+    #[test]
+    fn test_task_start_args_serialization_with_wait_for_exit_seconds() {
+        let args = TaskStartArgs {
+            unique_name: "tests-m".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            wait_for_exit_seconds: Some(15),
+        };
+
+        let json = serde_json::to_value(&args).unwrap();
+
+        assert_eq!(json["unique_name"], "tests-m");
+        assert_eq!(json["wait_for_exit_seconds"], 15);
+    }
+
+    #[test]
+    fn test_task_start_args_serialization_omits_wait_for_exit_seconds_when_absent() {
+        let args = TaskStartArgs {
+            unique_name: "tests-m".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            wait_for_exit_seconds: None,
+        };
+
+        let json = serde_json::to_value(&args).unwrap();
+
+        assert!(json.get("wait_for_exit_seconds").is_none());
+    }
 }

--- a/src/mcp/errors.rs
+++ b/src/mcp/errors.rs
@@ -113,6 +113,10 @@ impl DelaError {
     /// Create a RunnerUnavailable error with a helpful hint
     pub fn runner_unavailable(runner_name: String, task_name: String) -> Self {
         let hint = match runner_name.as_str() {
+            "cmake" => Some(
+                "CMake tasks are discovered for visibility, but MCP execution is disabled because the current CMake runner expands to a shell fragment. Run this task via the dela CLI instead."
+                    .to_string(),
+            ),
             "make" => Some(
                 "Install make: brew install make (macOS) or apt-get install make (Ubuntu)"
                     .to_string(),
@@ -224,7 +228,7 @@ mod tests {
                 .unwrap()
                 .as_str()
                 .unwrap()
-            .contains("list_tasks")
+                .contains("list_tasks")
         );
     }
 

--- a/src/mcp/errors.rs
+++ b/src/mcp/errors.rs
@@ -280,14 +280,13 @@ mod tests {
             .as_str()
             .unwrap()
             .to_string();
-        let poetry_hint =
-            DelaError::runner_unavailable("poetry".to_string(), "test".to_string())
-                .to_error_data()
-                .data
-                .unwrap()
-                .as_str()
-                .unwrap()
-                .to_string();
+        let poetry_hint = DelaError::runner_unavailable("poetry".to_string(), "test".to_string())
+            .to_error_data()
+            .data
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
         let poe_hint = DelaError::runner_unavailable("poe".to_string(), "test".to_string())
             .to_error_data()
             .data

--- a/src/mcp/errors.rs
+++ b/src/mcp/errors.rs
@@ -122,13 +122,31 @@ impl DelaError {
                     .to_string(),
             ),
             "npm" => Some("Install Node.js and npm: https://nodejs.org/".to_string()),
+            "yarn" => Some(
+                "Install Node.js, then enable Yarn via Corepack or install Yarn directly: https://yarnpkg.com/getting-started/install"
+                    .to_string(),
+            ),
+            "pnpm" => Some(
+                "Install Node.js, then enable pnpm via Corepack or install pnpm directly: https://pnpm.io/installation"
+                    .to_string(),
+            ),
+            "bun" => Some("Install Bun: https://bun.sh/docs/installation".to_string()),
             "gradle" => Some("Install Gradle: https://gradle.org/install/".to_string()),
-            "maven" => Some("Install Maven: https://maven.apache.org/install.html".to_string()),
-            "python" => Some("Install Python: https://python.org/downloads/".to_string()),
+            "mvn" => Some("Install Maven: https://maven.apache.org/install.html".to_string()),
             "uv" => {
                 Some("Install uv: pip install uv or https://github.com/astral-sh/uv".to_string())
             }
+            "poetry" => Some("Install Poetry: https://python-poetry.org/docs/#installation".to_string()),
+            "poe" => Some(
+                "Install Poe the Poet in this project environment, for example: uv tool install poethepoet or pip install poethepoet"
+                    .to_string(),
+            ),
             "just" => Some("Install just: https://github.com/casey/just#installation".to_string()),
+            "docker compose" => Some(
+                "Install Docker Desktop or Docker Engine with Compose support: https://docs.docker.com/compose/install/"
+                    .to_string(),
+            ),
+            "act" => Some("Install act: https://nektosact.com/installation/".to_string()),
             _ => Some(format!("Install {} to run this task", runner_name)),
         };
 
@@ -212,6 +230,77 @@ mod tests {
                 .unwrap()
                 .contains("brew install make")
         );
+    }
+
+    #[test]
+    fn test_runner_unavailable_node_package_manager_hints() {
+        let npm_hint = DelaError::runner_unavailable("npm".to_string(), "build".to_string())
+            .to_error_data()
+            .data
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+        let yarn_hint = DelaError::runner_unavailable("yarn".to_string(), "build".to_string())
+            .to_error_data()
+            .data
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+        let pnpm_hint = DelaError::runner_unavailable("pnpm".to_string(), "build".to_string())
+            .to_error_data()
+            .data
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+        let bun_hint = DelaError::runner_unavailable("bun".to_string(), "build".to_string())
+            .to_error_data()
+            .data
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert!(npm_hint.contains("Node.js and npm"));
+        assert!(yarn_hint.contains("Yarn"));
+        assert!(yarn_hint.contains("Corepack"));
+        assert!(pnpm_hint.contains("pnpm"));
+        assert!(pnpm_hint.contains("Corepack"));
+        assert!(bun_hint.contains("Bun"));
+    }
+
+    #[test]
+    fn test_runner_unavailable_python_tool_hints() {
+        let uv_hint = DelaError::runner_unavailable("uv".to_string(), "test".to_string())
+            .to_error_data()
+            .data
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+        let poetry_hint =
+            DelaError::runner_unavailable("poetry".to_string(), "test".to_string())
+                .to_error_data()
+                .data
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .to_string();
+        let poe_hint = DelaError::runner_unavailable("poe".to_string(), "test".to_string())
+            .to_error_data()
+            .data
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert!(uv_hint.contains("Install uv"));
+        assert!(!uv_hint.contains("Install Python"));
+        assert!(poetry_hint.contains("Install Poetry"));
+        assert!(poe_hint.contains("poethepoet"));
+        assert!(!poe_hint.contains("Install Python"));
     }
 
     #[test]

--- a/src/mcp/errors.rs
+++ b/src/mcp/errors.rs
@@ -20,6 +20,7 @@ impl DelaErrorCode {
     pub const NOT_ALLOWLISTED: Self = Self(-32010);
     pub const RUNNER_UNAVAILABLE: Self = Self(-32011);
     pub const TASK_NOT_FOUND: Self = Self(-32012);
+    pub const MCP_NOT_READY: Self = Self(-32013);
 }
 
 impl From<DelaErrorCode> for ErrorCode {
@@ -49,6 +50,11 @@ pub enum DelaError {
     },
     /// Generic internal error
     InternalError {
+        message: String,
+        hint: Option<String>,
+    },
+    /// MCP cannot start because local dela configuration is unavailable
+    McpNotReady {
         message: String,
         hint: Option<String>,
     },
@@ -85,6 +91,11 @@ impl DelaError {
             },
             DelaError::InternalError { message, hint } => ErrorData {
                 code: DelaErrorCode::INTERNAL_ERROR.into(),
+                message: Cow::Owned(message.clone()),
+                data: hint.as_ref().map(|h| Value::String(h.clone())),
+            },
+            DelaError::McpNotReady { message, hint } => ErrorData {
+                code: DelaErrorCode::MCP_NOT_READY.into(),
                 message: Cow::Owned(message.clone()),
                 data: hint.as_ref().map(|h| Value::String(h.clone())),
             },
@@ -135,6 +146,17 @@ impl DelaError {
     /// Create an InternalError with a helpful hint
     pub fn internal_error(message: String, hint: Option<String>) -> Self {
         DelaError::InternalError { message, hint }
+    }
+
+    /// Create an MCP-not-ready error with a helpful hint
+    pub fn mcp_not_ready(message: String) -> Self {
+        DelaError::McpNotReady {
+            message,
+            hint: Some(
+                "Run 'dela init' to create ~/.config/dela before starting the MCP server"
+                    .to_string(),
+            ),
+        }
     }
 }
 
@@ -202,7 +224,25 @@ mod tests {
                 .unwrap()
                 .as_str()
                 .unwrap()
-                .contains("list_tasks")
+            .contains("list_tasks")
+        );
+    }
+
+    #[test]
+    fn test_mcp_not_ready_error() {
+        let error = DelaError::mcp_not_ready("Dela is not initialized".to_string());
+        let error_data = error.to_error_data();
+
+        assert_eq!(error_data.code.0, -32013);
+        assert!(error_data.message.contains("not initialized"));
+        assert!(
+            error_data
+                .data
+                .as_ref()
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .contains("dela init")
         );
     }
 }

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -134,6 +134,7 @@ pub struct Job {
     pub metadata: JobMetadata,
     pub state: JobState,
     pub completed_at: Option<DateTime<Utc>>,
+    pub elapsed_at_completion: Option<Duration>,
     pub output_buffer: RingBuffer,
     pub last_activity: Instant,
 }
@@ -151,6 +152,7 @@ impl Job {
             metadata,
             state: JobState::Running,
             completed_at: None,
+            elapsed_at_completion: None,
             output_buffer: RingBuffer::new(max_output_lines, max_output_bytes),
             last_activity: Instant::now(),
         }
@@ -163,6 +165,7 @@ impl Job {
 
     /// Mark the job as exited with the given exit code
     pub fn mark_exited(&mut self, exit_code: i32) {
+        self.elapsed_at_completion = Some(self.metadata.started_at.elapsed());
         self.state = JobState::Exited(exit_code);
         self.completed_at = Some(Utc::now());
         self.touch();
@@ -170,6 +173,7 @@ impl Job {
 
     /// Mark the job as failed with the given error message
     pub fn mark_failed(&mut self, error: String) {
+        self.elapsed_at_completion = Some(self.metadata.started_at.elapsed());
         self.state = JobState::Failed(error);
         self.completed_at = Some(Utc::now());
         self.touch();
@@ -200,7 +204,8 @@ impl Job {
     /// Get the job's age
     #[allow(dead_code)]
     pub fn age(&self) -> Duration {
-        self.metadata.started_at.elapsed()
+        self.elapsed_at_completion
+            .unwrap_or_else(|| self.metadata.started_at.elapsed())
     }
 
     /// Get the time since last activity
@@ -291,6 +296,13 @@ impl JobManager {
             ));
         }
 
+        if matches!(jobs.get(&pid), Some(existing) if existing.is_running()) {
+            return Err(format!(
+                "Refusing to overwrite running job with PID {}",
+                pid
+            ));
+        }
+
         // Create the job
         let job = Job::new(
             pid,
@@ -316,6 +328,16 @@ impl JobManager {
         state: JobState,
     ) -> Result<(), String> {
         let mut jobs = self.jobs.write().await;
+        if matches!(jobs.get(&pid), Some(existing) if existing.is_running()) {
+            return Err(format!(
+                "Refusing to overwrite running job with PID {}",
+                pid
+            ));
+        }
+        let elapsed_at_completion = match state {
+            JobState::Running => None,
+            JobState::Exited(_) | JobState::Failed(_) => Some(metadata.started_at.elapsed()),
+        };
         jobs.insert(
             pid,
             Job {
@@ -325,6 +347,7 @@ impl JobManager {
                     JobState::Running => None,
                     JobState::Exited(_) | JobState::Failed(_) => Some(Utc::now()),
                 },
+                elapsed_at_completion,
                 state,
                 output_buffer: RingBuffer::new(
                     self.config.max_output_lines_per_job,
@@ -365,6 +388,7 @@ impl JobManager {
                 JobState::Running => {
                     job.state = JobState::Running;
                     job.completed_at = None;
+                    job.elapsed_at_completion = None;
                     job.touch();
                 }
                 JobState::Exited(exit_code) => job.mark_exited(exit_code),
@@ -945,5 +969,51 @@ mod tests {
         let job = manager.get_job(pid).await.unwrap();
         assert_eq!(job.state, JobState::Exited(0));
         assert!(job.completed_at.is_some());
+        assert!(job.elapsed_at_completion.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_record_completed_job_rejects_overwriting_running_job() {
+        let manager = JobManager::new();
+
+        let mut cmd = Command::new("sleep");
+        cmd.arg("5");
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let child = cmd.spawn().unwrap();
+        let pid = child.id().unwrap();
+
+        let metadata = JobMetadata {
+            started_at: Instant::now(),
+            unique_name: "test-task".to_string(),
+            source_name: "test".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            command: "sleep 5".to_string(),
+            file_path: PathBuf::from("Makefile"),
+        };
+
+        manager
+            .start_job(pid, metadata.clone(), child)
+            .await
+            .unwrap();
+
+        let result = manager
+            .record_completed_job(pid, metadata, JobState::Exited(0))
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Refusing to overwrite running job")
+        );
+
+        let job = manager.get_job(pid).await.unwrap();
+        assert!(job.is_running());
+
+        let _ = manager.stop_job_graceful(pid, 0).await;
     }
 }

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -132,6 +133,7 @@ pub struct Job {
     pub pid: u32,
     pub metadata: JobMetadata,
     pub state: JobState,
+    pub completed_at: Option<DateTime<Utc>>,
     pub output_buffer: RingBuffer,
     pub last_activity: Instant,
 }
@@ -148,6 +150,7 @@ impl Job {
             pid,
             metadata,
             state: JobState::Running,
+            completed_at: None,
             output_buffer: RingBuffer::new(max_output_lines, max_output_bytes),
             last_activity: Instant::now(),
         }
@@ -161,12 +164,14 @@ impl Job {
     /// Mark the job as exited with the given exit code
     pub fn mark_exited(&mut self, exit_code: i32) {
         self.state = JobState::Exited(exit_code);
+        self.completed_at = Some(Utc::now());
         self.touch();
     }
 
     /// Mark the job as failed with the given error message
     pub fn mark_failed(&mut self, error: String) {
         self.state = JobState::Failed(error);
+        self.completed_at = Some(Utc::now());
         self.touch();
     }
 
@@ -316,6 +321,10 @@ impl JobManager {
             Job {
                 pid,
                 metadata,
+                completed_at: match state {
+                    JobState::Running => None,
+                    JobState::Exited(_) | JobState::Failed(_) => Some(Utc::now()),
+                },
                 state,
                 output_buffer: RingBuffer::new(
                     self.config.max_output_lines_per_job,
@@ -352,8 +361,15 @@ impl JobManager {
     pub async fn update_job_state(&self, pid: u32, state: JobState) -> Result<(), String> {
         let mut jobs = self.jobs.write().await;
         if let Some(job) = jobs.get_mut(&pid) {
-            job.state = state;
-            job.touch();
+            match state {
+                JobState::Running => {
+                    job.state = JobState::Running;
+                    job.completed_at = None;
+                    job.touch();
+                }
+                JobState::Exited(exit_code) => job.mark_exited(exit_code),
+                JobState::Failed(error) => job.mark_failed(error),
+            }
             Ok(())
         } else {
             Err(format!("Job with PID {} not found", pid))
@@ -809,6 +825,7 @@ mod tests {
         let job = job.unwrap();
         assert_eq!(job.pid, pid);
         assert_eq!(job.metadata.unique_name, "test-task");
+        assert!(job.completed_at.is_none());
     }
 
     #[tokio::test]
@@ -894,5 +911,39 @@ mod tests {
         // Job should be removed
         let stats = manager.get_stats().await;
         assert_eq!(stats.total_jobs, 0);
+    }
+
+    #[tokio::test]
+    async fn test_job_manager_records_completion_metadata() {
+        let manager = JobManager::new();
+
+        let mut cmd = Command::new("echo");
+        cmd.arg("test");
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let child = cmd.spawn().unwrap();
+        let pid = child.id().unwrap();
+
+        let metadata = JobMetadata {
+            started_at: Instant::now(),
+            unique_name: "test-task".to_string(),
+            source_name: "test".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            command: "echo test".to_string(),
+            file_path: PathBuf::from("Makefile"),
+        };
+
+        manager.start_job(pid, metadata, child).await.unwrap();
+        manager
+            .update_job_state(pid, JobState::Exited(0))
+            .await
+            .unwrap();
+
+        let job = manager.get_job(pid).await.unwrap();
+        assert_eq!(job.state, JobState::Exited(0));
+        assert!(job.completed_at.is_some());
     }
 }

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -257,8 +257,10 @@ impl JobManager {
 
     /// Check if we can start a new job (concurrency limit check)
     pub async fn can_start_job(&self) -> Result<(), String> {
+        self.garbage_collect().await;
         let jobs = self.jobs.read().await;
-        if jobs.len() >= self.config.max_concurrent_jobs {
+        let running_jobs = jobs.values().filter(|job| job.is_running()).count();
+        if running_jobs >= self.config.max_concurrent_jobs {
             return Err(format!(
                 "Maximum concurrent jobs limit reached: {}",
                 self.config.max_concurrent_jobs
@@ -298,6 +300,30 @@ impl JobManager {
         let mut processes = self.processes.write().await;
         processes.insert(pid, process);
 
+        Ok(())
+    }
+
+    /// Record a completed job without retaining a process handle
+    pub async fn record_completed_job(
+        &self,
+        pid: u32,
+        metadata: JobMetadata,
+        state: JobState,
+    ) -> Result<(), String> {
+        let mut jobs = self.jobs.write().await;
+        jobs.insert(
+            pid,
+            Job {
+                pid,
+                metadata,
+                state,
+                output_buffer: RingBuffer::new(
+                    self.config.max_output_lines_per_job,
+                    self.config.max_output_bytes_per_job,
+                ),
+                last_activity: Instant::now(),
+            },
+        );
         Ok(())
     }
 
@@ -380,14 +406,42 @@ impl JobManager {
         // First, try to get the process from our managed processes
         let mut processes = self.processes.write().await;
         if let Some(mut process) = processes.remove(&pid) {
-            // Send SIGTERM
-            if let Err(e) = process.kill().await {
-                // Update job state to failed
-                let mut jobs = self.jobs.write().await;
-                if let Some(job) = jobs.get_mut(&pid) {
-                    job.mark_failed(format!("Failed to send SIGTERM: {}", e));
+            #[cfg(unix)]
+            {
+                use nix::sys::signal::{self, Signal};
+                use nix::unistd::Pid;
+
+                match signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
+                    Ok(()) => {}
+                    Err(nix::errno::Errno::ESRCH) => {
+                        let exit_status = process.wait().await.map_err(|e| {
+                            format!("Process already exited but wait failed: {}", e)
+                        })?;
+                        let exit_code = exit_status.code().unwrap_or(0);
+                        let mut jobs = self.jobs.write().await;
+                        if let Some(job) = jobs.get_mut(&pid) {
+                            job.mark_exited(exit_code);
+                        }
+                        return Ok(StopResult::Graceful(exit_code));
+                    }
+                    Err(e) => {
+                        let mut jobs = self.jobs.write().await;
+                        if let Some(job) = jobs.get_mut(&pid) {
+                            job.mark_failed(format!("Failed to send SIGTERM: {}", e));
+                        }
+                        return Ok(StopResult::Failed(format!("Failed to send SIGTERM: {}", e)));
+                    }
                 }
-                return Ok(StopResult::Failed(format!("Failed to send SIGTERM: {}", e)));
+            }
+            #[cfg(not(unix))]
+            {
+                if let Err(e) = process.kill().await {
+                    let mut jobs = self.jobs.write().await;
+                    if let Some(job) = jobs.get_mut(&pid) {
+                        job.mark_failed(format!("Failed to stop process: {}", e));
+                    }
+                    return Ok(StopResult::Failed(format!("Failed to stop process: {}", e)));
+                }
             }
 
             // Wait for the process to exit gracefully
@@ -414,9 +468,6 @@ impl JobManager {
                 }
                 Err(_) => {
                     // Grace period expired, send SIGKILL
-                    drop(processes); // Release the lock before trying to kill
-
-                    // Try to kill the process using native Rust signal handling
                     #[cfg(unix)]
                     {
                         use nix::sys::signal::{self, Signal};

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -25,6 +25,7 @@ use tokio::time::{Duration, timeout};
 
 const TASK_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(60);
 const DEFAULT_TASK_START_WAIT_SECONDS: u64 = 1;
+const MAX_TASK_START_WAIT_SECONDS: u64 = 3600;
 
 fn classify_output_log_level(stream: &str, line: &str) -> LoggingLevel {
     let normalized = line.trim().to_ascii_lowercase();
@@ -119,6 +120,24 @@ impl DelaMcpServer {
                     data,
                 })
                 .await;
+        }
+    }
+
+    fn resolve_wait_for_exit_seconds(wait_for_exit_seconds: Option<u64>) -> Result<u64, ErrorData> {
+        match wait_for_exit_seconds {
+            Some(seconds) if seconds <= MAX_TASK_START_WAIT_SECONDS => Ok(seconds),
+            Some(seconds) => Err(ErrorData {
+                code: super::errors::DelaErrorCode::INVALID_PARAMS.into(),
+                message: format!(
+                    "wait_for_exit_seconds must be between 0 and {} seconds, got {}",
+                    MAX_TASK_START_WAIT_SECONDS, seconds
+                )
+                .into(),
+                data: Some(serde_json::Value::String(
+                    "Use a bounded wait between 0 and 3600 seconds, or omit the field to use the 1-second default.".to_string(),
+                )),
+            }),
+            None => Ok(DEFAULT_TASK_START_WAIT_SECONDS),
         }
     }
 
@@ -240,7 +259,7 @@ impl DelaMcpServer {
                     "source_name": job.metadata.source_name,
                     "command": job.metadata.command,
                     "file_path": job.metadata.file_path.to_string_lossy(),
-                    "elapsed_seconds": job.metadata.started_at.elapsed().as_secs(),
+                    "elapsed_seconds": job.age().as_secs(),
                     "args": job.metadata.args,
                     "cwd": job.metadata.cwd.map(|p| p.to_string_lossy().to_string())
                 })
@@ -353,6 +372,8 @@ impl DelaMcpServer {
             cmd.current_dir(cwd);
         }
 
+        let started_at = Instant::now();
+
         // Start the process
         let mut child = cmd.spawn().map_err(|e| {
             DelaError::internal_error(
@@ -379,10 +400,9 @@ impl DelaMcpServer {
         .await;
 
         // Capture output until the bounded wait window expires while streaming via logging.
-        let capture_duration = Duration::from_secs(
-            args.wait_for_exit_seconds
-                .unwrap_or(DEFAULT_TASK_START_WAIT_SECONDS),
-        );
+        let capture_duration = Duration::from_secs(Self::resolve_wait_for_exit_seconds(
+            args.wait_for_exit_seconds,
+        )?);
         let initial_output = Arc::new(tokio::sync::Mutex::new(String::new()));
         let peer_clone = self.peer.clone();
 
@@ -544,7 +564,7 @@ impl DelaMcpServer {
 
             // Create job metadata and store it so task_status/task_output can query it
             let metadata = JobMetadata {
-                started_at: std::time::Instant::now(),
+                started_at,
                 unique_name: args.unique_name.clone(),
                 source_name: task.source_name.clone(),
                 args: args.args.clone(),
@@ -555,10 +575,15 @@ impl DelaMcpServer {
             };
 
             let exit_state = JobState::Exited(exit_code.unwrap_or(-1));
-            let _ = self
-                .job_manager
+            self.job_manager
                 .record_completed_job(pid as u32, metadata, exit_state)
-                .await;
+                .await
+                .map_err(|e| {
+                    DelaError::internal_error(
+                        format!("Failed to record completed job: {}", e),
+                        Some("Job management error".to_string()),
+                    )
+                })?;
 
             // Add output to the job record
             if !output.is_empty() {
@@ -596,7 +621,7 @@ impl DelaMcpServer {
 
         // Create job metadata
         let metadata = JobMetadata {
-            started_at: std::time::Instant::now(),
+            started_at,
             unique_name: args.unique_name.clone(),
             source_name: task.source_name.clone(),
             args: args.args.clone(),
@@ -771,7 +796,7 @@ impl DelaMcpServer {
                     "unique_name": job.metadata.unique_name,
                     "source_name": job.metadata.source_name,
                     "state": state,
-                    "elapsed_seconds": job.metadata.started_at.elapsed().as_secs(),
+                    "elapsed_seconds": job.age().as_secs(),
                     "exit_code": exit_code,
                     "completed_at": completed_at,
                     "command": job.metadata.command,
@@ -1173,10 +1198,20 @@ impl ServerHandler for DelaMcpServer {
             "type".to_string(),
             serde_json::Value::String("integer".to_string()),
         );
+        wait_for_exit_seconds_prop
+            .insert("minimum".to_string(), serde_json::Value::Number(0.into()));
+        wait_for_exit_seconds_prop.insert(
+            "maximum".to_string(),
+            serde_json::Value::Number(MAX_TASK_START_WAIT_SECONDS.into()),
+        );
         wait_for_exit_seconds_prop.insert(
             "description".to_string(),
             serde_json::Value::String(
-                "Optional bounded wait in seconds before backgrounding the task".to_string(),
+                format!(
+                    "Optional bounded wait in seconds before backgrounding the task. Defaults to {} second when omitted; allowed range: 0-{} seconds.",
+                    DEFAULT_TASK_START_WAIT_SECONDS,
+                    MAX_TASK_START_WAIT_SECONDS
+                ),
             ),
         );
         task_start_properties.insert(
@@ -3047,6 +3082,7 @@ add_custom_target(build-all COMMENT "Build everything")
     async fn test_task_start_wait_for_exit_returns_exited_within_window() {
         use std::os::unix::fs::PermissionsExt;
         use tempfile::TempDir;
+        use tokio::time::{Duration, sleep};
 
         let temp_dir = TempDir::new().unwrap();
         let script_path = temp_dir.path().join("waited_task.sh");
@@ -3120,6 +3156,28 @@ add_custom_target(build-all COMMENT "Build everything")
         let jobs = task_status_json["jobs"].as_array().unwrap();
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0]["state"], "exited");
+
+        sleep(Duration::from_secs(2)).await;
+
+        let task_status_result_later = server
+            .task_status(Parameters(TaskStatusArgs {
+                unique_name: "waited_task".to_string(),
+            }))
+            .await
+            .unwrap();
+        let task_status_json_later = match &task_status_result_later.content[0].raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content"),
+        };
+        let later_job = &task_status_json_later["jobs"].as_array().unwrap()[0];
+        let elapsed_seconds = later_job["elapsed_seconds"].as_u64().unwrap();
+        assert!(
+            (1..=2).contains(&elapsed_seconds),
+            "completed task elapsed_seconds should reflect its actual runtime, got {}",
+            elapsed_seconds
+        );
     }
 
     #[tokio::test]
@@ -3184,6 +3242,25 @@ add_custom_target(build-all COMMENT "Build everything")
         };
         assert_eq!(status_json["running"].as_array().unwrap().len(), 1);
 
+        let task_status_result = server
+            .task_status(Parameters(TaskStatusArgs {
+                unique_name: "still_running_task".to_string(),
+            }))
+            .await
+            .unwrap();
+        let task_status_json = match &task_status_result.content[0].raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content"),
+        };
+        let running_job = &task_status_json["jobs"].as_array().unwrap()[0];
+        assert_eq!(running_job["state"], "running");
+        assert!(
+            running_job["elapsed_seconds"].as_u64().unwrap() >= 2,
+            "elapsed_seconds should include the initial bounded wait window"
+        );
+
         let stop_result = server
             .task_stop(Parameters(TaskStopArgs {
                 pid,
@@ -3193,6 +3270,44 @@ add_custom_target(build-all COMMENT "Build everything")
         assert!(stop_result.is_ok());
 
         sleep(Duration::from_millis(200)).await;
+    }
+
+    #[tokio::test]
+    async fn test_task_start_wait_for_exit_rejects_values_above_max() {
+        use std::os::unix::fs::PermissionsExt;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let script_path = temp_dir.path().join("bounded_task.sh");
+        std::fs::write(&script_path, "#!/bin/bash\necho 'hi'\n").unwrap();
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let allowlist_evaluator = McpAllowlistEvaluator {
+            allowlist: crate::types::Allowlist {
+                entries: vec![crate::types::AllowlistEntry {
+                    path: script_path.clone(),
+                    scope: crate::types::AllowScope::File,
+                    tasks: None,
+                }],
+            },
+        };
+        let server =
+            DelaMcpServer::new_with_allowlist(temp_dir.path().to_path_buf(), allowlist_evaluator);
+
+        let result = server
+            .task_start(Parameters(TaskStartArgs {
+                unique_name: "bounded_task".to_string(),
+                args: None,
+                env: None,
+                cwd: None,
+                wait_for_exit_seconds: Some(MAX_TASK_START_WAIT_SECONDS + 1),
+            }))
+            .await;
+
+        let error = result.unwrap_err();
+        assert_eq!(error.code.0, -32602);
+        assert!(error.message.contains("wait_for_exit_seconds"));
+        assert!(error.message.contains("3600"));
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -34,8 +34,6 @@ impl DelaMcpServer {
     /// Create a new MCP server instance
     pub fn new(root: PathBuf) -> Self {
         let allowlist_evaluator = McpAllowlistEvaluator::new().unwrap_or_else(|_| {
-            // If allowlist loading fails, create an empty evaluator
-            // This allows the server to start even if allowlist is not available
             McpAllowlistEvaluator {
                 allowlist: crate::types::Allowlist::default(),
             }
@@ -177,7 +175,7 @@ impl DelaMcpServer {
                     "source_name": job.metadata.source_name,
                     "command": job.metadata.command,
                     "file_path": job.metadata.file_path.to_string_lossy(),
-                    "started_at": job.metadata.started_at.elapsed().as_secs(),
+                    "elapsed_seconds": job.metadata.started_at.elapsed().as_secs(),
                     "args": job.metadata.args,
                     "cwd": job.metadata.cwd.map(|p| p.to_string_lossy().to_string())
                 })
@@ -476,7 +474,7 @@ impl DelaMcpServer {
                 let _ = task.await;
             }
 
-            // Create job metadata and store it so task_status can query it
+            // Create job metadata and store it so task_status/task_output can query it
             let metadata = JobMetadata {
                 started_at: std::time::Instant::now(),
                 unique_name: args.unique_name.clone(),
@@ -488,20 +486,10 @@ impl DelaMcpServer {
                 file_path: task.file_path.clone(),
             };
 
-            // Create a dummy child process for the job manager
-            // We'll immediately mark it as exited
-            let dummy_child = Command::new("true").spawn().map_err(|e| {
-                DelaError::internal_error(format!("Failed to create job record: {}", e), None)
-            })?;
-
-            // Start and immediately mark as exited
+            let exit_state = JobState::Exited(exit_code.unwrap_or(-1));
             let _ = self
                 .job_manager
-                .start_job(pid as u32, metadata, dummy_child)
-                .await;
-            let _ = self
-                .job_manager
-                .update_job_state(pid as u32, JobState::Exited(exit_code.unwrap_or(-1)))
+                .record_completed_job(pid as u32, metadata, exit_state)
                 .await;
 
             // Add output to the job record
@@ -525,17 +513,13 @@ impl DelaMcpServer {
 
             let start_result = StartResultDto {
                 state: "exited".to_string(),
-                pid: Some(pid),
+                pid: None,
                 exit_code,
                 initial_output: output,
             };
 
             return Ok(CallToolResult::success(vec![
-                Content::json(&serde_json::json!({
-                    "ok": true,
-                    "result": start_result
-                }))
-                .expect("Failed to serialize JSON"),
+                Content::json(&start_result).expect("Failed to serialize JSON"),
             ]));
         }
 
@@ -691,11 +675,7 @@ impl DelaMcpServer {
         };
 
         Ok(CallToolResult::success(vec![
-            Content::json(&serde_json::json!({
-                "ok": true,
-                "result": start_result
-            }))
-            .expect("Failed to serialize JSON"),
+            Content::json(&start_result).expect("Failed to serialize JSON"),
         ]))
     }
 
@@ -719,7 +699,7 @@ impl DelaMcpServer {
                     "unique_name": job.metadata.unique_name,
                     "source_name": job.metadata.source_name,
                     "state": state,
-                    "started_at": job.metadata.started_at.elapsed().as_secs(),
+                    "elapsed_seconds": job.metadata.started_at.elapsed().as_secs(),
                     "command": job.metadata.command,
                     "file_path": job.metadata.file_path.to_string_lossy(),
                     "args": job.metadata.args,
@@ -2628,13 +2608,9 @@ test:
                         let json: serde_json::Value =
                             serde_json::from_str(&text_content.text).unwrap();
                         let obj = json.as_object().unwrap();
-                        assert!(obj.contains_key("ok"));
-                        assert!(obj.contains_key("result"));
-
-                        let result_obj = obj["result"].as_object().unwrap();
-                        assert!(result_obj.contains_key("state"));
+                        assert!(obj.contains_key("state"));
                         // Should be either "exited" (quick completion) or "running" (backgrounded)
-                        let state = result_obj["state"].as_str().unwrap();
+                        let state = obj["state"].as_str().unwrap();
                         assert!(state == "exited" || state == "running");
                     }
                     _ => panic!("Expected text content"),
@@ -2818,8 +2794,8 @@ test:
             RawContent::Text(text_content) => {
                 let json_response: serde_json::Value =
                     serde_json::from_str(&text_content.text).unwrap();
-                let pid = json_response["result"]["pid"].as_i64().unwrap() as u32;
-                let state = json_response["result"]["state"].as_str().unwrap();
+                let pid = json_response["pid"].as_i64().unwrap() as u32;
+                let state = json_response["state"].as_str().unwrap();
 
                 // Should start as running
                 println!("Task started with state: {}, pid: {}", state, pid);
@@ -3008,17 +2984,11 @@ test:
 
         // Parse start result
         let content = &start_response.content[0];
-        let (pid, _state) = match &content.raw {
+        let start_state = match &content.raw {
             RawContent::Text(text_content) => {
                 let json_response: serde_json::Value =
                     serde_json::from_str(&text_content.text).unwrap();
-                (
-                    json_response["result"]["pid"].as_i64().unwrap() as u32,
-                    json_response["result"]["state"]
-                        .as_str()
-                        .unwrap()
-                        .to_string(),
-                )
+                json_response["state"].as_str().unwrap().to_string()
             }
             _ => panic!("Expected text content"),
         };
@@ -3059,8 +3029,10 @@ test:
                 let jobs = task_status_json["jobs"].as_array().unwrap();
                 assert!(!jobs.is_empty());
                 let job = &jobs[0];
-                assert_eq!(job["pid"].as_i64().unwrap() as u32, pid);
                 assert_eq!(job["state"].as_str().unwrap(), "exited");
+                if start_state == "running" {
+                    assert!(job["pid"].is_number());
+                }
             }
             _ => panic!("Expected text content"),
         }
@@ -3117,7 +3089,7 @@ test:
             RawContent::Text(text_content) => {
                 let json_response: serde_json::Value =
                     serde_json::from_str(&text_content.text).unwrap();
-                json_response["result"]["pid"].as_i64().unwrap() as u32
+                json_response["pid"].as_i64().unwrap() as u32
             }
             _ => panic!("Expected text content"),
         };

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -26,6 +26,31 @@ use tokio::time::{Duration, timeout};
 const TASK_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(60);
 const DEFAULT_TASK_START_WAIT_SECONDS: u64 = 1;
 
+fn classify_output_log_level(stream: &str, line: &str) -> LoggingLevel {
+    let normalized = line.trim().to_ascii_lowercase();
+
+    let is_error = normalized.starts_with("error")
+        || normalized.starts_with("fatal:")
+        || normalized.contains(" panicked at")
+        || normalized.starts_with("thread '")
+        || normalized.starts_with("failures:");
+    if is_error {
+        return LoggingLevel::Error;
+    }
+
+    let is_warning = normalized.starts_with("warning")
+        || normalized.starts_with("warn:")
+        || normalized.contains(" warning:");
+    if is_warning {
+        return LoggingLevel::Warning;
+    }
+
+    match stream {
+        "stderr" => LoggingLevel::Info,
+        _ => LoggingLevel::Info,
+    }
+}
+
 #[derive(Debug, Clone)]
 struct CachedDiscoveredTasks {
     discovered: task_discovery::DiscoveredTasks,
@@ -437,7 +462,7 @@ impl DelaMcpServer {
                         // Stream via logging notification
                         if let Some(peer) = peer_for_initial.get() {
                             let _ = peer.notify_logging_message(LoggingMessageNotificationParam {
-                                level: LoggingLevel::Info,
+                                level: classify_output_log_level("stdout", &line),
                                 logger: Some(format!("task:{}", pid_u32)),
                                 data: serde_json::json!({
                                     "type": "stdout",
@@ -462,7 +487,7 @@ impl DelaMcpServer {
                         // Stream via logging notification
                         if let Some(peer) = peer_for_initial.get() {
                             let _ = peer.notify_logging_message(LoggingMessageNotificationParam {
-                                level: LoggingLevel::Warning,
+                                level: classify_output_log_level("stderr", &line),
                                 logger: Some(format!("task:{}", pid_u32)),
                                 data: serde_json::json!({
                                     "type": "stderr",
@@ -637,7 +662,7 @@ impl DelaMcpServer {
                         // Stream via logging
                         if let Some(peer) = peer_for_monitor.get() {
                             let _ = peer.notify_logging_message(LoggingMessageNotificationParam {
-                                level: LoggingLevel::Info,
+                                level: classify_output_log_level("stdout", &line),
                                 logger: Some(format!("task:{}", pid_u32)),
                                 data: serde_json::json!({
                                     "type": "stdout",
@@ -659,7 +684,7 @@ impl DelaMcpServer {
                         // Stream via logging
                         if let Some(peer) = peer_for_monitor.get() {
                             let _ = peer.notify_logging_message(LoggingMessageNotificationParam {
-                                level: LoggingLevel::Warning,
+                                level: classify_output_log_level("stderr", &line),
                                 logger: Some(format!("task:{}", pid_u32)),
                                 data: serde_json::json!({
                                     "type": "stderr",
@@ -936,7 +961,7 @@ impl ServerHandler for DelaMcpServer {
                 )
         )
         .with_instructions(
-            "List tasks, start them (≤1s capture then background), and manage running tasks via PID; all execution gated by an MCP allowlist. Subscribe to logging notifications for real-time task output streaming."
+            "List tasks, start them with a default 1-second capture window or an optional wait_for_exit_seconds bounded wait, and manage running tasks via PID; all execution is gated by an MCP allowlist. Subscribe to logging notifications for real-time task output streaming."
         )
     }
 
@@ -3626,5 +3651,35 @@ add_custom_target(build-all COMMENT "Build everything")
                 level
             );
         }
+    }
+
+    #[test]
+    fn test_classify_output_log_level() {
+        assert_eq!(
+            classify_output_log_level("stderr", "   Compiling dela v0.0.6"),
+            LoggingLevel::Info
+        );
+        assert_eq!(
+            classify_output_log_level("stderr", "warning: unused variable"),
+            LoggingLevel::Warning
+        );
+        assert_eq!(
+            classify_output_log_level("stderr", "error: could not compile `dela`"),
+            LoggingLevel::Error
+        );
+        assert_eq!(
+            classify_output_log_level("stdout", "regular test output"),
+            LoggingLevel::Info
+        );
+    }
+
+    #[test]
+    fn test_server_info_instructions_mentions_bounded_wait() {
+        let server = DelaMcpServer::new(PathBuf::from("."));
+        let info = server.get_info();
+        let instructions = info.instructions.expect("instructions should be present");
+
+        assert!(instructions.contains("wait_for_exit_seconds"));
+        assert!(instructions.contains("default 1-second capture window"));
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -16,16 +16,27 @@ use rmcp::{
 };
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, BufReader, stdin, stdout};
 use tokio::process::Command;
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, RwLock};
 use tokio::time::{Duration, timeout};
+
+const TASK_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone)]
+struct CachedDiscoveredTasks {
+    discovered: task_discovery::DiscoveredTasks,
+    cached_at: Instant,
+}
 
 /// MCP server for dela that exposes task management capabilities
 pub struct DelaMcpServer {
     root: PathBuf,
     allowlist_evaluator: McpAllowlistEvaluator,
     job_manager: JobManager,
+    task_cache: Arc<RwLock<Option<CachedDiscoveredTasks>>>,
+    task_cache_ttl: Duration,
     /// Peer connection for sending notifications (set during initialize)
     peer: Arc<OnceCell<Peer<RoleServer>>>,
 }
@@ -38,11 +49,21 @@ impl DelaMcpServer {
                 allowlist: crate::types::Allowlist::default(),
             }
         });
+        Self::new_inner(root, allowlist_evaluator, TASK_DISCOVERY_CACHE_TTL)
+    }
+
+    fn new_inner(
+        root: PathBuf,
+        allowlist_evaluator: McpAllowlistEvaluator,
+        task_cache_ttl: Duration,
+    ) -> Self {
         let job_manager = JobManager::new();
         Self {
             root,
             allowlist_evaluator,
             job_manager,
+            task_cache: Arc::new(RwLock::new(None)),
+            task_cache_ttl,
             peer: Arc::new(OnceCell::new()),
         }
     }
@@ -50,13 +71,16 @@ impl DelaMcpServer {
     /// Create a new MCP server instance with a custom allowlist evaluator (for testing)
     #[cfg(test)]
     pub fn new_with_allowlist(root: PathBuf, allowlist_evaluator: McpAllowlistEvaluator) -> Self {
-        let job_manager = JobManager::new();
-        Self {
-            root,
-            allowlist_evaluator,
-            job_manager,
-            peer: Arc::new(OnceCell::new()),
-        }
+        Self::new_inner(root, allowlist_evaluator, TASK_DISCOVERY_CACHE_TTL)
+    }
+
+    #[cfg(test)]
+    pub fn new_with_allowlist_and_cache_ttl(
+        root: PathBuf,
+        allowlist_evaluator: McpAllowlistEvaluator,
+        task_cache_ttl: Duration,
+    ) -> Self {
+        Self::new_inner(root, allowlist_evaluator, task_cache_ttl)
     }
 
     /// Send a logging notification to the client (if connected)
@@ -111,6 +135,25 @@ impl DelaMcpServer {
         &self.root
     }
 
+    async fn get_discovered_tasks(&self) -> task_discovery::DiscoveredTasks {
+        {
+            let cache = self.task_cache.read().await;
+            if let Some(entry) = cache.as_ref() {
+                if entry.cached_at.elapsed() < self.task_cache_ttl {
+                    return entry.discovered.clone();
+                }
+            }
+        }
+
+        let discovered = task_discovery::discover_tasks(&self.root);
+        let mut cache = self.task_cache.write().await;
+        *cache = Some(CachedDiscoveredTasks {
+            discovered: discovered.clone(),
+            cached_at: Instant::now(),
+        });
+        discovered
+    }
+
     /// Start an MCP stdio server and block until shutdown.
     /// IMPORTANT: Do not print to stdout; MCP JSON-RPC uses stdout.
     pub async fn serve_stdio(self) -> Result<(), ErrorData> {
@@ -135,11 +178,7 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<ListTasksArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        // Discover tasks in the current directory
-        let mut discovered = task_discovery::discover_tasks(&self.root);
-
-        // Process task disambiguation to generate uniqified names
-        task_discovery::process_task_disambiguation(&mut discovered);
+        let discovered = self.get_discovered_tasks().await;
 
         // Apply runner filtering if specified
         let mut tasks = discovered.tasks;
@@ -195,9 +234,7 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<TaskStartArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        // Find the task by unique name
-        let mut discovered = task_discovery::discover_tasks(&self.root);
-        task_discovery::process_task_disambiguation(&mut discovered);
+        let discovered = self.get_discovered_tasks().await;
 
         let task = discovered
             .tasks
@@ -2221,6 +2258,97 @@ test:
         // Assert
         assert_eq!(result.content.len(), 1);
         // The test succeeded, which means TaskDto conversion worked
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_uses_cached_discovery_within_ttl() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("Makefile"), "build:\n\techo \"Building\"\n").unwrap();
+
+        let allowlist_evaluator = McpAllowlistEvaluator {
+            allowlist: crate::types::Allowlist::default(),
+        };
+        let server = DelaMcpServer::new_with_allowlist_and_cache_ttl(
+            temp_path.to_path_buf(),
+            allowlist_evaluator,
+            Duration::from_secs(60),
+        );
+
+        let first_result = server
+            .list_tasks(Parameters(ListTasksArgs::default()))
+            .await
+            .unwrap();
+
+        fs::write(temp_path.join("Makefile"), "test:\n\techo \"Testing\"\n").unwrap();
+
+        let second_result = server
+            .list_tasks(Parameters(ListTasksArgs::default()))
+            .await
+            .unwrap();
+
+        let first_json = match &first_result.content[0].raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content with JSON"),
+        };
+        let second_json = match &second_result.content[0].raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content with JSON"),
+        };
+
+        assert_eq!(first_json["tasks"][0]["source_name"], "build");
+        assert_eq!(second_json["tasks"][0]["source_name"], "build");
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_refreshes_after_cache_ttl_expires() {
+        use std::fs;
+        use tempfile::TempDir;
+        use tokio::time::sleep;
+
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        fs::write(temp_path.join("Makefile"), "build:\n\techo \"Building\"\n").unwrap();
+
+        let allowlist_evaluator = McpAllowlistEvaluator {
+            allowlist: crate::types::Allowlist::default(),
+        };
+        let server = DelaMcpServer::new_with_allowlist_and_cache_ttl(
+            temp_path.to_path_buf(),
+            allowlist_evaluator,
+            Duration::from_millis(50),
+        );
+
+        let _ = server
+            .list_tasks(Parameters(ListTasksArgs::default()))
+            .await
+            .unwrap();
+
+        fs::write(temp_path.join("Makefile"), "test:\n\techo \"Testing\"\n").unwrap();
+        sleep(Duration::from_millis(75)).await;
+
+        let refreshed_result = server
+            .list_tasks(Parameters(ListTasksArgs::default()))
+            .await
+            .unwrap();
+
+        let refreshed_json = match &refreshed_result.content[0].raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content with JSON"),
+        };
+
+        assert_eq!(refreshed_json["tasks"][0]["source_name"], "test");
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -5,7 +5,7 @@ use super::dto::{
 };
 use super::errors::DelaError;
 use super::job_manager::{JobManager, JobMetadata, JobState};
-use crate::runner::{is_runner_available, split_command_words};
+use crate::runner::{is_runner_available_for_mcp, split_command_words};
 use crate::task_discovery;
 use rmcp::{
     ServerHandler, ServiceExt,
@@ -44,11 +44,10 @@ pub struct DelaMcpServer {
 impl DelaMcpServer {
     /// Create a new MCP server instance
     pub fn new(root: PathBuf) -> Self {
-        let allowlist_evaluator = McpAllowlistEvaluator::new().unwrap_or_else(|_| {
-            McpAllowlistEvaluator {
+        let allowlist_evaluator =
+            McpAllowlistEvaluator::new().unwrap_or_else(|_| McpAllowlistEvaluator {
                 allowlist: crate::types::Allowlist::default(),
-            }
-        });
+            });
         Self::new_inner(root, allowlist_evaluator, TASK_DISCOVERY_CACHE_TTL)
     }
 
@@ -261,7 +260,7 @@ impl DelaMcpServer {
         }
 
         // Check if runner is available
-        if !is_runner_available(&task.runner) {
+        if !is_runner_available_for_mcp(&task.runner) {
             return Err(DelaError::runner_unavailable(
                 task.runner.short_name().to_string(),
                 args.unique_name.clone(),
@@ -2619,6 +2618,55 @@ test:
         assert!(error.message.contains("nonexistent-task"));
         // Check that it's a TASK_NOT_FOUND error
         assert_eq!(error.code.0, -32012);
+    }
+
+    #[tokio::test]
+    async fn test_task_start_cmake_disabled_for_mcp() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+        let cmake_path = temp_path.join("CMakeLists.txt");
+
+        let cmake_content = r#"
+cmake_minimum_required(VERSION 3.10)
+project(TestProject)
+
+add_custom_target(build-all COMMENT "Build everything")
+"#;
+        fs::write(&cmake_path, cmake_content).unwrap();
+
+        let allowlist_evaluator = McpAllowlistEvaluator {
+            allowlist: crate::types::Allowlist {
+                entries: vec![crate::types::AllowlistEntry {
+                    path: cmake_path,
+                    scope: crate::types::AllowScope::File,
+                    tasks: None,
+                }],
+            },
+        };
+
+        let server =
+            DelaMcpServer::new_with_allowlist(temp_path.to_path_buf(), allowlist_evaluator);
+        let args = Parameters(TaskStartArgs {
+            unique_name: "build-all".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+        });
+
+        let result = server.task_start(args).await;
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.code.0, -32011);
+        assert!(error.message.contains("Runner 'cmake' is not available"));
+        let hint = error
+            .data
+            .and_then(|value| value.as_str().map(str::to_string));
+        assert!(hint.is_some());
+        assert!(hint.unwrap().contains("MCP execution is disabled"));
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -26,6 +26,9 @@ use tokio::time::{Duration, timeout};
 const TASK_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(60);
 const DEFAULT_TASK_START_WAIT_SECONDS: u64 = 1;
 const MAX_TASK_START_WAIT_SECONDS: u64 = 3600;
+const OUTPUT_NOTIFICATION_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+const OUTPUT_NOTIFICATION_MAX_BYTES: usize = 4 * 1024;
+const OUTPUT_NOTIFICATION_MAX_LINES: usize = 100;
 
 fn classify_output_log_level(stream: &str, line: &str) -> LoggingLevel {
     let normalized = line.trim().to_ascii_lowercase();
@@ -49,6 +52,90 @@ fn classify_output_log_level(stream: &str, line: &str) -> LoggingLevel {
     match stream {
         "stderr" => LoggingLevel::Info,
         _ => LoggingLevel::Info,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct OutputNotificationEntry {
+    line: String,
+    level: LoggingLevel,
+}
+
+#[derive(Debug, Clone)]
+struct OutputNotificationBatch {
+    stream: &'static str,
+    entries: Vec<OutputNotificationEntry>,
+    total_bytes: usize,
+    started_at: Option<Instant>,
+}
+
+impl OutputNotificationBatch {
+    fn new(stream: &'static str) -> Self {
+        Self {
+            stream,
+            entries: Vec::new(),
+            total_bytes: 0,
+            started_at: None,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn add_line(&mut self, line: &str) {
+        if self.started_at.is_none() {
+            self.started_at = Some(Instant::now());
+        }
+
+        self.total_bytes += line.len();
+        self.entries.push(OutputNotificationEntry {
+            line: line.trim_end().to_string(),
+            level: classify_output_log_level(self.stream, line),
+        });
+    }
+
+    fn should_flush(&self) -> bool {
+        self.entries.len() >= OUTPUT_NOTIFICATION_MAX_LINES
+            || self.total_bytes >= OUTPUT_NOTIFICATION_MAX_BYTES
+    }
+
+    fn flush_due_at(&self) -> Option<Instant> {
+        self.started_at
+            .map(|started_at| started_at + OUTPUT_NOTIFICATION_FLUSH_INTERVAL)
+    }
+
+    fn take_notification_data(&mut self, pid: u32) -> Option<(LoggingLevel, serde_json::Value)> {
+        if self.entries.is_empty() {
+            return None;
+        }
+
+        let entries = std::mem::take(&mut self.entries);
+        let _total_bytes = std::mem::take(&mut self.total_bytes);
+        self.started_at = None;
+
+        let batch_level = if entries
+            .iter()
+            .any(|entry| entry.level == LoggingLevel::Error)
+        {
+            LoggingLevel::Error
+        } else if entries
+            .iter()
+            .any(|entry| entry.level == LoggingLevel::Warning)
+        {
+            LoggingLevel::Warning
+        } else {
+            LoggingLevel::Info
+        };
+
+        let lines: Vec<String> = entries.iter().map(|entry| entry.line.clone()).collect();
+        let data = serde_json::json!({
+            "type": self.stream,
+            "pid": pid,
+            "lines": lines,
+        });
+
+        Some((batch_level, data))
     }
 }
 
@@ -121,6 +208,53 @@ impl DelaMcpServer {
                 })
                 .await;
         }
+    }
+
+    fn append_initial_output(output: &mut String, stream: &str, line: &str) {
+        match stream {
+            "stderr" => {
+                if !output.contains("STDERR:") {
+                    if !output.is_empty() {
+                        output.push('\n');
+                    }
+                    output.push_str("STDERR:\n");
+                }
+            }
+            _ => {
+                if output.is_empty() {
+                    output.push_str("STDOUT:\n");
+                }
+            }
+        }
+
+        output.push_str(line);
+    }
+
+    async fn flush_output_notification_batch(
+        peer: &Arc<OnceCell<Peer<RoleServer>>>,
+        pid: u32,
+        batch: &mut OutputNotificationBatch,
+    ) {
+        let Some((level, data)) = batch.take_notification_data(pid) else {
+            return;
+        };
+
+        if let Some(peer) = peer.get() {
+            let _ = peer
+                .notify_logging_message(LoggingMessageNotificationParam {
+                    level,
+                    logger: Some(format!("task:{}", pid)),
+                    data,
+                })
+                .await;
+        }
+    }
+
+    fn output_flush_timer_deadline(
+        deadline: Option<Instant>,
+        fallback: Instant,
+    ) -> tokio::time::Instant {
+        tokio::time::Instant::from_std(deadline.unwrap_or(fallback))
     }
 
     fn resolve_wait_for_exit_seconds(wait_for_exit_seconds: Option<u64>) -> Result<u64, ErrorData> {
@@ -463,67 +597,136 @@ impl DelaMcpServer {
             let deadline = std::time::Instant::now() + capture_duration;
             let mut stdout_done = false;
             let mut stderr_done = false;
+            let mut stdout_batch = OutputNotificationBatch::new("stdout");
+            let mut stderr_batch = OutputNotificationBatch::new("stderr");
 
             loop {
-                if std::time::Instant::now() >= deadline {
+                let now = std::time::Instant::now();
+                if now >= deadline {
+                    DelaMcpServer::flush_output_notification_batch(
+                        &peer_for_initial,
+                        pid_u32,
+                        &mut stdout_batch,
+                    )
+                    .await;
+                    DelaMcpServer::flush_output_notification_batch(
+                        &peer_for_initial,
+                        pid_u32,
+                        &mut stderr_batch,
+                    )
+                    .await;
                     break;
                 }
 
                 tokio::select! {
-                    Some(line) = stdout_rx.recv(), if !stdout_done => {
-                        // Add to initial output
-                        {
-                            let mut output = initial_output_clone.lock().await;
-                            if output.is_empty() {
-                                output.push_str("STDOUT:\n");
-                            }
-                            output.push_str(&line);
-                        }
-                        // Stream via logging notification
-                        if let Some(peer) = peer_for_initial.get() {
-                            let _ = peer.notify_logging_message(LoggingMessageNotificationParam {
-                                level: classify_output_log_level("stdout", &line),
-                                logger: Some(format!("task:{}", pid_u32)),
-                                data: serde_json::json!({
-                                    "type": "stdout",
-                                    "pid": pid_u32,
-                                    "line": line.trim_end()
-                                }),
-                            }).await;
-                        }
-                    }
-                    Some(line) = stderr_rx.recv(), if !stderr_done => {
-                        // Add to initial output
-                        {
-                            let mut output = initial_output_clone.lock().await;
-                            if !output.contains("STDERR:") {
-                                if !output.is_empty() {
-                                    output.push('\n');
+                    line = stdout_rx.recv(), if !stdout_done => {
+                        match line {
+                            Some(line) => {
+                                {
+                                    let mut output = initial_output_clone.lock().await;
+                                    DelaMcpServer::append_initial_output(&mut output, "stdout", &line);
                                 }
-                                output.push_str("STDERR:\n");
+                                stdout_batch.add_line(&line);
+                                if stdout_batch.should_flush() {
+                                    DelaMcpServer::flush_output_notification_batch(
+                                        &peer_for_initial,
+                                        pid_u32,
+                                        &mut stdout_batch,
+                                    )
+                                    .await;
+                                }
                             }
-                            output.push_str(&line);
-                        }
-                        // Stream via logging notification
-                        if let Some(peer) = peer_for_initial.get() {
-                            let _ = peer.notify_logging_message(LoggingMessageNotificationParam {
-                                level: classify_output_log_level("stderr", &line),
-                                logger: Some(format!("task:{}", pid_u32)),
-                                data: serde_json::json!({
-                                    "type": "stderr",
-                                    "pid": pid_u32,
-                                    "line": line.trim_end()
-                                }),
-                            }).await;
+                            None => {
+                                stdout_done = true;
+                                DelaMcpServer::flush_output_notification_batch(
+                                    &peer_for_initial,
+                                    pid_u32,
+                                    &mut stdout_batch,
+                                )
+                                .await;
+                            }
                         }
                     }
-                    else => {
-                        stdout_done = true;
-                        stderr_done = true;
+                    line = stderr_rx.recv(), if !stderr_done => {
+                        match line {
+                            Some(line) => {
+                                {
+                                    let mut output = initial_output_clone.lock().await;
+                                    DelaMcpServer::append_initial_output(&mut output, "stderr", &line);
+                                }
+                                stderr_batch.add_line(&line);
+                                if stderr_batch.should_flush() {
+                                    DelaMcpServer::flush_output_notification_batch(
+                                        &peer_for_initial,
+                                        pid_u32,
+                                        &mut stderr_batch,
+                                    )
+                                    .await;
+                                }
+                            }
+                            None => {
+                                stderr_done = true;
+                                DelaMcpServer::flush_output_notification_batch(
+                                    &peer_for_initial,
+                                    pid_u32,
+                                    &mut stderr_batch,
+                                )
+                                .await;
+                            }
+                        }
+                    }
+                    _ = tokio::time::sleep_until(DelaMcpServer::output_flush_timer_deadline(
+                        stdout_batch.flush_due_at(),
+                        deadline,
+                    )), if !stdout_batch.is_empty() => {
+                        DelaMcpServer::flush_output_notification_batch(
+                            &peer_for_initial,
+                            pid_u32,
+                            &mut stdout_batch,
+                        )
+                        .await;
+                    }
+                    _ = tokio::time::sleep_until(DelaMcpServer::output_flush_timer_deadline(
+                        stderr_batch.flush_due_at(),
+                        deadline,
+                    )), if !stderr_batch.is_empty() => {
+                        DelaMcpServer::flush_output_notification_batch(
+                            &peer_for_initial,
+                            pid_u32,
+                            &mut stderr_batch,
+                        )
+                        .await;
+                    }
+                    _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {
+                        DelaMcpServer::flush_output_notification_batch(
+                            &peer_for_initial,
+                            pid_u32,
+                            &mut stdout_batch,
+                        )
+                        .await;
+                        DelaMcpServer::flush_output_notification_batch(
+                            &peer_for_initial,
+                            pid_u32,
+                            &mut stderr_batch,
+                        )
+                        .await;
+                        break;
                     }
                 }
 
                 if stdout_done && stderr_done {
+                    DelaMcpServer::flush_output_notification_batch(
+                        &peer_for_initial,
+                        pid_u32,
+                        &mut stdout_batch,
+                    )
+                    .await;
+                    DelaMcpServer::flush_output_notification_batch(
+                        &peer_for_initial,
+                        pid_u32,
+                        &mut stderr_batch,
+                    )
+                    .await;
                     break;
                 }
             }
@@ -668,6 +871,9 @@ impl DelaMcpServer {
             } else {
                 (None, None)
             };
+            let mut stdout_batch = OutputNotificationBatch::new("stdout");
+            let mut stderr_batch = OutputNotificationBatch::new("stderr");
+            let idle_deadline_fallback = Instant::now() + Duration::from_secs(24 * 60 * 60);
 
             // Continue reading output and streaming
             loop {
@@ -675,52 +881,104 @@ impl DelaMcpServer {
                 let stderr_done = stderr_rx_opt.is_none();
 
                 tokio::select! {
-                    Some(line) = async {
+                    line = async {
                         if let Some(ref mut rx) = stdout_rx_opt {
                             rx.recv().await
                         } else {
                             std::future::pending::<Option<String>>().await
                         }
                     }, if !stdout_done => {
-                        // Add to ring buffer
-                        let _ = job_manager.add_job_output(pid_u32, line.clone()).await;
-                        // Stream via logging
-                        if let Some(peer) = peer_for_monitor.get() {
-                            let _ = peer.notify_logging_message(LoggingMessageNotificationParam {
-                                level: classify_output_log_level("stdout", &line),
-                                logger: Some(format!("task:{}", pid_u32)),
-                                data: serde_json::json!({
-                                    "type": "stdout",
-                                    "pid": pid_u32,
-                                    "line": line.trim_end()
-                                }),
-                            }).await;
+                        match line {
+                            Some(line) => {
+                                let _ = job_manager.add_job_output(pid_u32, line.clone()).await;
+                                stdout_batch.add_line(&line);
+                                if stdout_batch.should_flush() {
+                                    DelaMcpServer::flush_output_notification_batch(
+                                        &peer_for_monitor,
+                                        pid_u32,
+                                        &mut stdout_batch,
+                                    )
+                                    .await;
+                                }
+                            }
+                            None => {
+                                stdout_rx_opt = None;
+                                DelaMcpServer::flush_output_notification_batch(
+                                    &peer_for_monitor,
+                                    pid_u32,
+                                    &mut stdout_batch,
+                                )
+                                .await;
+                            }
                         }
                     }
-                    Some(line) = async {
+                    line = async {
                         if let Some(ref mut rx) = stderr_rx_opt {
                             rx.recv().await
                         } else {
                             std::future::pending::<Option<String>>().await
                         }
                     }, if !stderr_done => {
-                        // Add to ring buffer
-                        let _ = job_manager.add_job_output(pid_u32, line.clone()).await;
-                        // Stream via logging
-                        if let Some(peer) = peer_for_monitor.get() {
-                            let _ = peer.notify_logging_message(LoggingMessageNotificationParam {
-                                level: classify_output_log_level("stderr", &line),
-                                logger: Some(format!("task:{}", pid_u32)),
-                                data: serde_json::json!({
-                                    "type": "stderr",
-                                    "pid": pid_u32,
-                                    "line": line.trim_end()
-                                }),
-                            }).await;
+                        match line {
+                            Some(line) => {
+                                let _ = job_manager.add_job_output(pid_u32, line.clone()).await;
+                                stderr_batch.add_line(&line);
+                                if stderr_batch.should_flush() {
+                                    DelaMcpServer::flush_output_notification_batch(
+                                        &peer_for_monitor,
+                                        pid_u32,
+                                        &mut stderr_batch,
+                                    )
+                                    .await;
+                                }
+                            }
+                            None => {
+                                stderr_rx_opt = None;
+                                DelaMcpServer::flush_output_notification_batch(
+                                    &peer_for_monitor,
+                                    pid_u32,
+                                    &mut stderr_batch,
+                                )
+                                .await;
+                            }
                         }
+                    }
+                    _ = tokio::time::sleep_until(DelaMcpServer::output_flush_timer_deadline(
+                        stdout_batch.flush_due_at(),
+                        idle_deadline_fallback,
+                    )), if !stdout_batch.is_empty() => {
+                        DelaMcpServer::flush_output_notification_batch(
+                            &peer_for_monitor,
+                            pid_u32,
+                            &mut stdout_batch,
+                        )
+                        .await;
+                    }
+                    _ = tokio::time::sleep_until(DelaMcpServer::output_flush_timer_deadline(
+                        stderr_batch.flush_due_at(),
+                        idle_deadline_fallback,
+                    )), if !stderr_batch.is_empty() => {
+                        DelaMcpServer::flush_output_notification_batch(
+                            &peer_for_monitor,
+                            pid_u32,
+                            &mut stderr_batch,
+                        )
+                        .await;
                     }
                     else => {
                         // Both channels closed
+                        DelaMcpServer::flush_output_notification_batch(
+                            &peer_for_monitor,
+                            pid_u32,
+                            &mut stdout_batch,
+                        )
+                        .await;
+                        DelaMcpServer::flush_output_notification_batch(
+                            &peer_for_monitor,
+                            pid_u32,
+                            &mut stderr_batch,
+                        )
+                        .await;
                         break;
                     }
                 }
@@ -3786,6 +4044,38 @@ add_custom_target(build-all COMMENT "Build everything")
             classify_output_log_level("stdout", "regular test output"),
             LoggingLevel::Info
         );
+    }
+
+    #[test]
+    fn test_output_notification_batch_preserves_per_line_levels() {
+        let mut batch = OutputNotificationBatch::new("stderr");
+        batch.add_line("plain stderr line\n");
+        batch.add_line("warning: this is a warning\n");
+        batch.add_line("error: this is an error\n");
+
+        let (level, data) = batch.take_notification_data(1234).unwrap();
+        assert_eq!(level, LoggingLevel::Error);
+        assert_eq!(data["type"], "stderr");
+        assert_eq!(data["pid"], 1234);
+        assert_eq!(data["lines"].as_array().unwrap().len(), 3);
+        assert_eq!(data["lines"][0], "plain stderr line");
+        assert_eq!(data["lines"][1], "warning: this is a warning");
+        assert_eq!(data["lines"][2], "error: this is an error");
+        assert!(data.get("line").is_none());
+        assert!(data.get("entries").is_none());
+        assert!(data.get("chunk").is_none());
+        assert!(data.get("byte_count").is_none());
+        assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn test_output_notification_batch_flushes_at_line_limit() {
+        let mut batch = OutputNotificationBatch::new("stdout");
+        for index in 0..OUTPUT_NOTIFICATION_MAX_LINES {
+            batch.add_line(&format!("line {}\n", index));
+        }
+
+        assert!(batch.should_flush());
     }
 
     #[test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -23,6 +23,7 @@ use tokio::sync::{OnceCell, RwLock};
 use tokio::time::{Duration, timeout};
 
 const TASK_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(60);
+const DEFAULT_TASK_START_WAIT_SECONDS: u64 = 1;
 
 #[derive(Debug, Clone)]
 struct CachedDiscoveredTasks {
@@ -228,7 +229,9 @@ impl DelaMcpServer {
         ]))
     }
 
-    #[tool(description = "Start a task (≤1s capture, then background)")]
+    #[tool(
+        description = "Start a task (default 1s capture, optional bounded wait, then background)"
+    )]
     pub async fn task_start(
         &self,
         Parameters(args): Parameters<TaskStartArgs>,
@@ -349,8 +352,11 @@ impl DelaMcpServer {
         )
         .await;
 
-        // Capture initial output for up to 1 second while streaming via logging
-        let capture_duration = Duration::from_secs(1);
+        // Capture output until the bounded wait window expires while streaming via logging.
+        let capture_duration = Duration::from_secs(
+            args.wait_for_exit_seconds
+                .unwrap_or(DEFAULT_TASK_START_WAIT_SECONDS),
+        );
         let initial_output = Arc::new(tokio::sync::Mutex::new(String::new()));
         let peer_clone = self.peer.clone();
 
@@ -1129,6 +1135,23 @@ impl ServerHandler for DelaMcpServer {
         );
         task_start_properties.insert("cwd".to_string(), serde_json::Value::Object(cwd_prop));
 
+        // wait_for_exit_seconds (optional)
+        let mut wait_for_exit_seconds_prop = Map::new();
+        wait_for_exit_seconds_prop.insert(
+            "type".to_string(),
+            serde_json::Value::String("integer".to_string()),
+        );
+        wait_for_exit_seconds_prop.insert(
+            "description".to_string(),
+            serde_json::Value::String(
+                "Optional bounded wait in seconds before backgrounding the task".to_string(),
+            ),
+        );
+        task_start_properties.insert(
+            "wait_for_exit_seconds".to_string(),
+            serde_json::Value::Object(wait_for_exit_seconds_prop),
+        );
+
         task_start_schema.insert(
             "properties".to_string(),
             serde_json::Value::Object(task_start_properties),
@@ -1288,7 +1311,10 @@ impl ServerHandler for DelaMcpServer {
             ),
             Tool::new_with_raw(
                 "task_start",
-                Some("Start a task (≤1s capture, then background)".into()),
+                Some(
+                    "Start a task (default 1s capture, optional bounded wait, then background)"
+                        .into(),
+                ),
                 task_start_schema,
             ),
             Tool::new_with_raw(
@@ -2606,6 +2632,7 @@ test:
             args: None,
             env: None,
             cwd: None,
+            wait_for_exit_seconds: None,
         });
 
         // Act
@@ -2654,6 +2681,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: None,
             env: None,
             cwd: None,
+            wait_for_exit_seconds: None,
         });
 
         let result = server.task_start(args).await;
@@ -2691,6 +2719,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: None,
             env: None,
             cwd: None,
+            wait_for_exit_seconds: None,
         });
         let result = server.task_start(args).await;
         assert!(result.is_err());
@@ -2766,6 +2795,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: None,
             env: None,
             cwd: None,
+            wait_for_exit_seconds: None,
         });
 
         // Act
@@ -2820,6 +2850,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: Some(vec!["--verbose".to_string(), "--debug".to_string()]),
             env: None,
             cwd: None,
+            wait_for_exit_seconds: None,
         });
 
         // Act
@@ -2862,6 +2893,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: None,
             env: Some(env_vars),
             cwd: None,
+            wait_for_exit_seconds: None,
         });
 
         // Act
@@ -2901,6 +2933,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: None,
             env: None,
             cwd: Some(temp_path.to_string_lossy().to_string()),
+            wait_for_exit_seconds: None,
         });
 
         // Act
@@ -2917,6 +2950,158 @@ add_custom_target(build-all COMMENT "Build everything")
                 // The important thing is that we're testing the working directory setting path
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_task_start_wait_for_exit_returns_exited_within_window() {
+        use std::os::unix::fs::PermissionsExt;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let script_path = temp_dir.path().join("waited_task.sh");
+        std::fs::write(
+            &script_path,
+            "#!/bin/bash\necho 'Starting...'\nsleep 2\necho 'Finished within wait window'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let allowlist_evaluator = McpAllowlistEvaluator {
+            allowlist: crate::types::Allowlist {
+                entries: vec![crate::types::AllowlistEntry {
+                    path: script_path.clone(),
+                    scope: crate::types::AllowScope::File,
+                    tasks: None,
+                }],
+            },
+        };
+        let server =
+            DelaMcpServer::new_with_allowlist(temp_dir.path().to_path_buf(), allowlist_evaluator);
+
+        let args = Parameters(TaskStartArgs {
+            unique_name: "waited_task".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            wait_for_exit_seconds: Some(3),
+        });
+
+        let result = server.task_start(args).await.unwrap();
+        let content = &result.content[0];
+        let json = match &content.raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content"),
+        };
+
+        assert_eq!(json["state"], "exited");
+        assert_eq!(json["exit_code"], 0);
+        assert!(json.get("pid").is_none());
+        assert!(
+            json["initial_output"]
+                .as_str()
+                .unwrap()
+                .contains("Finished within wait window")
+        );
+
+        let status_result = server.status().await.unwrap();
+        let status_json = match &status_result.content[0].raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content"),
+        };
+        assert_eq!(status_json["running"].as_array().unwrap().len(), 0);
+
+        let task_status_result = server
+            .task_status(Parameters(TaskStatusArgs {
+                unique_name: "waited_task".to_string(),
+            }))
+            .await
+            .unwrap();
+        let task_status_json = match &task_status_result.content[0].raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content"),
+        };
+        let jobs = task_status_json["jobs"].as_array().unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0]["state"], "exited");
+    }
+
+    #[tokio::test]
+    async fn test_task_start_wait_for_exit_backgrounds_after_timeout() {
+        use std::os::unix::fs::PermissionsExt;
+        use tempfile::TempDir;
+        use tokio::time::{Duration, sleep};
+
+        let temp_dir = TempDir::new().unwrap();
+        let script_path = temp_dir.path().join("still_running_task.sh");
+        std::fs::write(
+            &script_path,
+            "#!/bin/bash\necho 'Starting...'\nsleep 4\necho 'Finished after timeout'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let allowlist_evaluator = McpAllowlistEvaluator {
+            allowlist: crate::types::Allowlist {
+                entries: vec![crate::types::AllowlistEntry {
+                    path: script_path.clone(),
+                    scope: crate::types::AllowScope::File,
+                    tasks: None,
+                }],
+            },
+        };
+        let server =
+            DelaMcpServer::new_with_allowlist(temp_dir.path().to_path_buf(), allowlist_evaluator);
+
+        let args = Parameters(TaskStartArgs {
+            unique_name: "still_running_task".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            wait_for_exit_seconds: Some(2),
+        });
+
+        let result = server.task_start(args).await.unwrap();
+        let content = &result.content[0];
+        let json = match &content.raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content"),
+        };
+
+        assert_eq!(json["state"], "running");
+        let pid = json["pid"].as_i64().unwrap() as u32;
+        assert!(
+            json["initial_output"]
+                .as_str()
+                .unwrap()
+                .contains("Starting...")
+        );
+
+        let status_result = server.status().await.unwrap();
+        let status_json = match &status_result.content[0].raw {
+            RawContent::Text(text_content) => {
+                serde_json::from_str::<serde_json::Value>(&text_content.text).unwrap()
+            }
+            _ => panic!("Expected text content"),
+        };
+        assert_eq!(status_json["running"].as_array().unwrap().len(), 1);
+
+        let stop_result = server
+            .task_stop(Parameters(TaskStopArgs {
+                pid,
+                grace_period: Some(1),
+            }))
+            .await;
+        assert!(stop_result.is_ok());
+
+        sleep(Duration::from_millis(200)).await;
     }
 
     #[tokio::test]
@@ -2958,6 +3143,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: None,
             env: None,
             cwd: None,
+            wait_for_exit_seconds: None,
         };
 
         let start_result = server.task_start(Parameters(start_args)).await;
@@ -3155,6 +3341,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: None,
             env: None,
             cwd: None,
+            wait_for_exit_seconds: None,
         };
         let start_response = server.task_start(Parameters(start_args)).await.unwrap();
 
@@ -3256,6 +3443,7 @@ add_custom_target(build-all COMMENT "Build everything")
             args: None,
             env: None,
             cwd: None,
+            wait_for_exit_seconds: None,
         };
         let start_response = server.task_start(Parameters(start_args)).await.unwrap();
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,6 +7,7 @@ use super::errors::DelaError;
 use super::job_manager::{JobManager, JobMetadata, JobState};
 use crate::runner::{is_runner_available_for_mcp, split_command_words};
 use crate::task_discovery;
+use chrono::SecondsFormat;
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::wrapper::Parameters,
@@ -730,11 +731,15 @@ impl DelaMcpServer {
         let job_statuses: Vec<serde_json::Value> = jobs
             .into_iter()
             .map(|job| {
-                let state = match job.state {
-                    JobState::Running => "running",
-                    JobState::Exited(_) => "exited",
-                    JobState::Failed(_) => "failed",
+                let (state, exit_code) = match &job.state {
+                    JobState::Running => ("running", None),
+                    JobState::Exited(code) => ("exited", Some(*code)),
+                    JobState::Failed(_) => ("failed", None),
                 };
+                let completed_at = job
+                    .completed_at
+                    .as_ref()
+                    .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Secs, true));
 
                 serde_json::json!({
                     "pid": job.pid,
@@ -742,6 +747,8 @@ impl DelaMcpServer {
                     "source_name": job.metadata.source_name,
                     "state": state,
                     "elapsed_seconds": job.metadata.started_at.elapsed().as_secs(),
+                    "exit_code": exit_code,
+                    "completed_at": completed_at,
                     "command": job.metadata.command,
                     "file_path": job.metadata.file_path.to_string_lossy(),
                     "args": job.metadata.args,
@@ -1614,6 +1621,8 @@ mod tests {
                     assert!(job["pid"].is_number());
                     assert!(job["state"].is_string());
                     assert_eq!(job["state"], "running");
+                    assert!(job["exit_code"].is_null());
+                    assert!(job["completed_at"].is_null());
                 }
             }
             _ => panic!("Expected text content with JSON"),
@@ -1680,6 +1689,63 @@ mod tests {
                 let job = &jobs[0];
                 assert_eq!(job["unique_name"], "test-task");
                 assert_eq!(job["state"], "exited");
+                assert_eq!(job["exit_code"], 0);
+                assert!(job["completed_at"].is_string());
+            }
+            _ => panic!("Expected text content with JSON"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_task_status_failed_job_includes_completed_at() {
+        let temp_dir = std::env::temp_dir();
+        let server = DelaMcpServer::new(temp_dir);
+
+        let metadata = JobMetadata {
+            started_at: std::time::Instant::now(),
+            unique_name: "test-task".to_string(),
+            source_name: "test".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            command: "echo test".to_string(),
+            file_path: PathBuf::from("Makefile"),
+        };
+
+        let mut cmd = tokio::process::Command::new("echo");
+        cmd.arg("test");
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        let child = cmd.spawn().unwrap();
+        let pid = child.id().unwrap();
+
+        server
+            .job_manager
+            .start_job(pid as u32, metadata, child)
+            .await
+            .unwrap();
+        server
+            .job_manager
+            .update_job_state(pid as u32, JobState::Failed("boom".to_string()))
+            .await
+            .unwrap();
+
+        let result = server
+            .task_status(Parameters(TaskStatusArgs {
+                unique_name: "test-task".to_string(),
+            }))
+            .await
+            .unwrap();
+
+        let content = &result.content[0];
+        match &content.raw {
+            RawContent::Text(text_content) => {
+                let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
+                let jobs = json["jobs"].as_array().unwrap();
+                assert_eq!(jobs.len(), 1);
+                assert_eq!(jobs[0]["state"], "failed");
+                assert!(jobs[0]["exit_code"].is_null());
+                assert!(jobs[0]["completed_at"].is_string());
             }
             _ => panic!("Expected text content with JSON"),
         }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -44,6 +44,16 @@ pub fn is_runner_available(runner: &TaskRunner) -> bool {
     }
 }
 
+/// MCP can only execute runners that expand to a single direct process invocation.
+/// CMake currently expands to a shell fragment with `&&`, so we expose it but do not
+/// allow MCP clients to execute it.
+pub fn is_runner_available_for_mcp(runner: &TaskRunner) -> bool {
+    match runner {
+        TaskRunner::CMake => false,
+        _ => is_runner_available(runner),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -270,6 +280,22 @@ mod tests {
 
         // Docker Compose should not be available
         assert!(!is_runner_available(&TaskRunner::DockerCompose));
+
+        reset_mock();
+        reset_to_real_environment();
+    }
+
+    #[test]
+    #[serial]
+    fn test_cmake_runner_disabled_for_mcp() {
+        reset_mock();
+        enable_mock();
+
+        let env = TestEnvironment::new().with_executable("cmake");
+        set_test_environment(env);
+
+        assert!(is_runner_available(&TaskRunner::CMake));
+        assert!(!is_runner_available_for_mcp(&TaskRunner::CMake));
 
         reset_mock();
         reset_to_real_environment();

--- a/src/task_discovery.rs
+++ b/src/task_discovery.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 // Define the DiscoveredTaskDefinitions type directly here
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct DiscoveredTaskDefinitions {
     pub makefile: Option<TaskDefinitionFile>,
     pub package_json: Option<TaskDefinitionFile>,
@@ -29,7 +29,7 @@ pub struct DiscoveredTaskDefinitions {
 }
 
 /// Result of task discovery
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct DiscoveredTasks {
     /// Task definition files found
     pub definitions: DiscoveredTaskDefinitions,

--- a/tests/docker_mcp/Dockerfile
+++ b/tests/docker_mcp/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p /home/testuser/test_project /home/testuser/.config/dela && \
 # Create allowlist with MCP-allowlisted tasks
 RUN echo 'entries = [' > /home/testuser/.config/dela/allowlist.toml && \
     echo '  { path = "/home/testuser/test_project/package.json", scope = "Task", tasks = ["npm-test", "npm-start"] },' >> /home/testuser/.config/dela/allowlist.toml && \
-    echo '  { path = "/home/testuser/test_project/Makefile", scope = "Task", tasks = ["make-build", "make-test", "test-task", "another-task", "print-args", "long-running-task"] }' >> /home/testuser/.config/dela/allowlist.toml && \
+    echo '  { path = "/home/testuser/test_project/Makefile", scope = "Task", tasks = ["make-build", "make-test", "test-task", "another-task", "print-args", "long-running-task", "stderr-level-task"] }' >> /home/testuser/.config/dela/allowlist.toml && \
     echo ']' >> /home/testuser/.config/dela/allowlist.toml && \
     chown testuser:testuser /home/testuser/.config/dela/allowlist.toml && \
     chmod 644 /home/testuser/.config/dela/allowlist.toml

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -1,33 +1,44 @@
 #!/usr/bin/env python3
-"""
-Simple MCP protocol test using Python subprocess and JSON-RPC
-"""
+"""Dockerized MCP integration test covering the current dela MCP contract."""
+
 import json
+import os
 import subprocess
 import sys
 import time
-import os
 
-def start_mcp_process(cwd):
-    """Start MCP process and perform handshake"""
+
+PROJECT_CWD = "/home/testuser/test_project"
+MCP_COMMAND = ["/usr/local/bin/dela", "mcp", "--cwd", PROJECT_CWD]
+
+
+def fail(message, *, payload=None):
+    print(f"✗ {message}")
+    if payload is not None:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return False
+
+
+def start_mcp_process():
     env = os.environ.copy()
-    env.update({
-        "RUST_LOG": "warn",
-        "MCPI_NO_COLOR": "1"
-    })
-    
+    env.update(
+        {
+            "RUST_LOG": "warn",
+            "MCPI_NO_COLOR": "1",
+        }
+    )
+
     process = subprocess.Popen(
-        ["/usr/local/bin/dela", "mcp", "--cwd", cwd],
+        MCP_COMMAND,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        cwd=cwd,
-        env=env
+        cwd=PROJECT_CWD,
+        env=env,
     )
-    
-    # Send initialize request
-    init_request = {
+
+    initialize_request = {
         "jsonrpc": "2.0",
         "id": 1,
         "method": "initialize",
@@ -35,1270 +46,543 @@ def start_mcp_process(cwd):
             "protocolVersion": "2024-11-05",
             "capabilities": {},
             "clientInfo": {
-                "name": "test-client",
-                "version": "1.0.0"
-            }
-        }
+                "name": "docker-mcp-test",
+                "version": "1.0.0",
+            },
+        },
     }
-    
-    process.stdin.write(json.dumps(init_request) + "\n")
+    process.stdin.write(json.dumps(initialize_request) + "\n")
     process.stdin.flush()
-    
-    # Wait for initialize response with timeout
-    try:
-        response_line = process.stdout.readline()
-        if not response_line:
-            print("✗ No response from MCP server")
-            process.kill()
-            return None
-        print(f"Initialize response: {response_line.strip()}")
-    except Exception as e:
-        print(f"✗ Error reading initialize response: {e}")
+
+    init_response, _ = read_until_response(process, initialize_request["id"])
+    if "result" not in init_response:
         process.kill()
-        return None
-    
-    # Send initialized notification
+        raise RuntimeError(f"initialize failed: {init_response}")
+
     initialized_notification = {
         "jsonrpc": "2.0",
-        "method": "notifications/initialized"
+        "method": "notifications/initialized",
     }
-    
     process.stdin.write(json.dumps(initialized_notification) + "\n")
     process.stdin.flush()
-    
-    # Wait for handshake to complete
-    time.sleep(1)
-    
-    return process
+    return process, init_response
 
-def send_request(process, request):
-    """Send a request and return the response matching the request id (skip log lines)."""
-    process.stdin.write(json.dumps(request) + "\n")
-    process.stdin.flush()
-    target_id = request.get("id")
-    while True:
+
+def stop_process(process):
+    if process.poll() is None:
+        process.kill()
+        try:
+            process.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+def read_json_line(process, timeout_seconds=10):
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
         line = process.stdout.readline()
         if not line:
-            return {"error": "no response"}
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            # Skip non-JSON lines
+            stderr = process.stderr.read()
+            raise RuntimeError(f"mcp server closed stdout early; stderr={stderr!r}")
+        line = line.strip()
+        if not line:
             continue
-        if target_id is None or payload.get("id") == target_id:
-            return payload
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise TimeoutError("timed out waiting for json-rpc message")
 
-def test_mcp_protocol():
-    """Test MCP protocol communication"""
+
+def read_until_response(process, request_id, timeout_seconds=10):
+    notifications = []
+    deadline = time.time() + timeout_seconds
+
+    while time.time() < deadline:
+        message = read_json_line(process, timeout_seconds=max(1, deadline - time.time()))
+        if message.get("id") == request_id:
+            return message, notifications
+        if "method" in message:
+            notifications.append(message)
+
+    raise TimeoutError(f"timed out waiting for response id {request_id}")
+
+
+def send_request(process, request, timeout_seconds=10):
+    process.stdin.write(json.dumps(request) + "\n")
+    process.stdin.flush()
+    return read_until_response(process, request["id"], timeout_seconds=timeout_seconds)
+
+
+def parse_tool_result(response):
+    result = response.get("result")
+    if not result:
+        raise AssertionError(f"expected result payload, got: {response}")
+
+    content = result.get("content") or []
+    if not content:
+        raise AssertionError(f"expected content payload, got: {response}")
+
+    text = content[0].get("text")
+    if text is None:
+        raise AssertionError(f"expected text payload, got: {response}")
+
+    return json.loads(text)
+
+
+def tool_request(request_id, name, arguments=None):
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {
+            "name": name,
+            "arguments": arguments or {},
+        },
+    }
+
+
+def assert_condition(condition, message, payload=None):
+    if not condition:
+        raise AssertionError(message if payload is None else f"{message}: {payload}")
+
+
+def find_task(tasks, unique_name):
+    for task in tasks:
+        if task.get("unique_name") == unique_name:
+            return task
+    raise AssertionError(f"task {unique_name!r} not found in {tasks!r}")
+
+
+def find_job(jobs, unique_name, pid=None):
+    for job in jobs:
+        if job.get("unique_name") != unique_name:
+            continue
+        if pid is not None and job.get("pid") != pid:
+            continue
+        return job
+    raise AssertionError(f"job {unique_name!r} pid={pid!r} not found in {jobs!r}")
+
+
+def logging_notifications(notifications):
+    return [n for n in notifications if n.get("method") == "notifications/message"]
+
+
+def test_initialize_instructions():
+    print("Test 1: initialize advertises bounded wait and logging")
+    process, init_response = start_mcp_process()
+    try:
+        info = init_response["result"]["serverInfo"]
+        instructions = init_response["result"].get("instructions", "")
+        assert_condition(
+            "wait_for_exit_seconds" in instructions,
+            "instructions missing wait_for_exit_seconds",
+            instructions,
+        )
+        assert_condition(
+            "default 1-second capture window" in instructions,
+            "instructions missing default capture wording",
+            instructions,
+        )
+        assert_condition(
+            info["name"],
+            "serverInfo.name should be present",
+            info,
+        )
+        print("✓ initialize response includes current MCP instructions")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_tools_list_schema():
+    print("Test 2: tools/list exposes MCP tool surface and bounded wait schema")
+    process, _ = start_mcp_process()
+    try:
+        response, _ = send_request(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {},
+            },
+        )
+        tools = response["result"]["tools"]
+        names = {tool["name"] for tool in tools}
+        expected = {"list_tasks", "task_start", "status", "task_status", "task_output", "task_stop"}
+        assert_condition(expected.issubset(names), "missing tools", list(names))
+
+        task_start = next(tool for tool in tools if tool["name"] == "task_start")
+        properties = task_start["inputSchema"]["properties"]
+        wait_prop = properties.get("wait_for_exit_seconds")
+        assert_condition(wait_prop is not None, "task_start missing wait_for_exit_seconds", properties)
+        assert_condition(
+            wait_prop.get("type") == "integer",
+            "wait_for_exit_seconds should be integer",
+            wait_prop,
+        )
+        print("✓ tools/list exposes current task_start schema")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_list_tasks_enriched_fields():
+    print("Test 3: list_tasks returns enriched fields")
+    process, _ = start_mcp_process()
+    try:
+        response, _ = send_request(process, tool_request(3, "list_tasks"))
+        payload = parse_tool_result(response)
+        tasks = payload["tasks"]
+        test_task = find_task(tasks, "test-task")
+        for field in [
+            "unique_name",
+            "source_name",
+            "runner",
+            "command",
+            "runner_available",
+            "allowlisted",
+            "file_path",
+        ]:
+            assert_condition(field in test_task, f"missing list_tasks field {field}", test_task)
+        print("✓ list_tasks returns enriched task metadata")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_task_start_quick_exit():
+    print("Test 4: task_start returns direct quick-exit payload")
+    process, _ = start_mcp_process()
+    try:
+        response, notifications = send_request(
+            process,
+            tool_request(4, "task_start", {"unique_name": "test-task"}),
+            timeout_seconds=10,
+        )
+        payload = parse_tool_result(response)
+        assert_condition(payload["state"] == "exited", "quick task should exit", payload)
+        assert_condition(payload.get("pid") is None, "quick exit should not report pid", payload)
+        assert_condition(payload.get("exit_code") == 0, "quick exit should report exit_code 0", payload)
+        assert_condition(
+            "Test task executed successfully" in payload["initial_output"],
+            "quick exit missing task output",
+            payload,
+        )
+        assert_condition(
+            all("ok" not in item for item in payload.keys()),
+            "quick exit payload should not use legacy ok/result wrapper",
+            payload,
+        )
+        assert_condition(
+            any(n.get("method") == "notifications/message" for n in notifications),
+            "quick exit should stream at least one logging notification",
+            notifications,
+        )
+        print("✓ task_start quick-exit contract matches current MCP shape")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_task_start_args_and_spaces():
+    print("Test 5: task_start preserves space-containing args for the underlying runner")
+    process, _ = start_mcp_process()
+    try:
+        response, _ = send_request(
+            process,
+            tool_request(
+                5,
+                "task_start",
+                {
+                    "unique_name": "print-args",
+                    "args": ["ARGS=value with spaces"],
+                },
+            ),
+        )
+        payload = parse_tool_result(response)
+        assert_condition(payload["state"] == "exited", "print-args should exit", payload)
+        assert_condition(payload.get("exit_code") == 0, "print-args should exit successfully", payload)
+        output = payload["initial_output"]
+        assert_condition("value with spaces" in output, "missing spaced arg in output", payload)
+        print("✓ task_start preserves passed arguments")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_error_taxonomy():
+    print("Test 6: task_start returns current TaskNotFound and NotAllowlisted errors")
+    process, _ = start_mcp_process()
+    try:
+        not_found_response, _ = send_request(
+            process,
+            tool_request(6, "task_start", {"unique_name": "nonexistent-task"}),
+        )
+        not_found = not_found_response.get("error", {})
+        assert_condition(not_found.get("code") == -32012, "wrong TaskNotFound code", not_found_response)
+        assert_condition("not found" in not_found.get("message", ""), "wrong TaskNotFound message", not_found)
+
+        deny_response, _ = send_request(
+            process,
+            tool_request(7, "task_start", {"unique_name": "custom-exe"}),
+        )
+        denied = deny_response.get("error", {})
+        assert_condition(denied.get("code") == -32010, "wrong NotAllowlisted code", deny_response)
+        assert_condition(
+            "not allowlisted" in denied.get("message", ""),
+            "wrong NotAllowlisted message",
+            denied,
+        )
+        print("✓ task_start error taxonomy matches MCP contract")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_bounded_wait_completion():
+    print("Test 7: task_start bounded wait returns completed task in one round trip")
+    process, _ = start_mcp_process()
+    try:
+        response, notifications = send_request(
+            process,
+            tool_request(
+                8,
+                "task_start",
+                {
+                    "unique_name": "long-running-task",
+                    "wait_for_exit_seconds": 7,
+                },
+            ),
+            timeout_seconds=15,
+        )
+        payload = parse_tool_result(response)
+        assert_condition(payload["state"] == "exited", "bounded wait should complete task", payload)
+        assert_condition(payload.get("exit_code") == 0, "bounded wait should return exit_code 0", payload)
+        assert_condition(payload.get("pid") is None, "bounded wait completion should not return pid", payload)
+        assert_condition(
+            "Starting long-running task..." in payload["initial_output"],
+            "missing initial stdout from bounded wait task",
+            payload,
+        )
+        assert_condition(
+            "Long-running task completed successfully" in payload["initial_output"],
+            "missing completion stdout from bounded wait task",
+            payload,
+        )
+        assert_condition(
+            len(logging_notifications(notifications)) >= 2,
+            "bounded wait should stream logging notifications while waiting",
+            notifications,
+        )
+        print("✓ task_start bounded wait works for completed tasks")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_task_status_completion_metadata():
+    print("Test 8: task_status exposes exit_code and completed_at for completed jobs")
+    process, _ = start_mcp_process()
+    try:
+        send_request(
+            process,
+            tool_request(9, "task_start", {"unique_name": "test-task"}),
+        )
+        status_response, _ = send_request(
+            process,
+            tool_request(10, "task_status", {"unique_name": "test-task"}),
+        )
+        payload = parse_tool_result(status_response)
+        job = find_job(payload["jobs"], "test-task")
+        assert_condition(job["state"] == "exited", "completed test-task should be exited", job)
+        assert_condition(job["exit_code"] == 0, "completed test-task should expose exit_code", job)
+        assert_condition(
+            isinstance(job["completed_at"], str) and job["completed_at"],
+            "completed test-task should expose completed_at",
+            job,
+        )
+        print("✓ task_status exposes completion metadata")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_running_lifecycle_and_stop():
+    print("Test 9: background execution, status, output, and stop lifecycle")
+    process, _ = start_mcp_process()
+    try:
+        start_response, _ = send_request(
+            process,
+            tool_request(11, "task_start", {"unique_name": "long-running-task"}),
+            timeout_seconds=10,
+        )
+        start_payload = parse_tool_result(start_response)
+        assert_condition(start_payload["state"] == "running", "default start should background task", start_payload)
+        pid = start_payload.get("pid")
+        assert_condition(isinstance(pid, int) and pid > 0, "running task should expose pid", start_payload)
+        assert_condition(
+            "Starting long-running task..." in start_payload["initial_output"],
+            "running task missing initial output",
+            start_payload,
+        )
+
+        status_response, _ = send_request(process, tool_request(12, "status"))
+        running = parse_tool_result(status_response)["running"]
+        running_job = find_job(running, "long-running-task", pid=pid)
+        assert_condition(running_job["pid"] == pid, "status should report the running pid", running_job)
+        assert_condition(
+            isinstance(running_job.get("elapsed_seconds"), int),
+            "status should include elapsed_seconds",
+            running_job,
+        )
+
+        task_status_response, _ = send_request(
+            process,
+            tool_request(13, "task_status", {"unique_name": "long-running-task"}),
+        )
+        task_status_job = find_job(parse_tool_result(task_status_response)["jobs"], "long-running-task", pid=pid)
+        assert_condition(task_status_job["state"] == "running", "task_status should report running state", task_status_job)
+        assert_condition(task_status_job["exit_code"] is None, "running job should not have exit_code", task_status_job)
+        assert_condition(
+            task_status_job["completed_at"] is None,
+            "running job should not have completed_at",
+            task_status_job,
+        )
+
+        output_response, _ = send_request(
+            process,
+            tool_request(14, "task_output", {"pid": pid, "lines": 50, "show_truncation": True}),
+        )
+        output_payload = parse_tool_result(output_response)
+        assert_condition(output_payload["pid"] == pid, "task_output pid mismatch", output_payload)
+        assert_condition(output_payload["lines"], "task_output should contain captured lines", output_payload)
+
+        stop_response, _ = send_request(
+            process,
+            tool_request(15, "task_stop", {"pid": pid, "grace_period": 2}),
+            timeout_seconds=10,
+        )
+        stop_payload = parse_tool_result(stop_response)
+        assert_condition(stop_payload["pid"] == pid, "task_stop pid mismatch", stop_payload)
+        assert_condition(
+            stop_payload["status"] in {"graceful", "killed", "failed"},
+            "unexpected task_stop status",
+            stop_payload,
+        )
+
+        status_after_stop, _ = send_request(process, tool_request(16, "status"))
+        running_after_stop = parse_tool_result(status_after_stop)["running"]
+        assert_condition(
+            all(job.get("pid") != pid for job in running_after_stop),
+            "stopped task should disappear from running list",
+            running_after_stop,
+        )
+        print("✓ running-task lifecycle works through stop")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_nonexistent_job_tools():
+    print("Test 10: task_output and task_stop reject nonexistent jobs")
+    process, _ = start_mcp_process()
+    try:
+        output_response, _ = send_request(
+            process,
+            tool_request(17, "task_output", {"pid": 99999, "lines": 10, "show_truncation": True}),
+        )
+        assert_condition("error" in output_response, "task_output should error for bad pid", output_response)
+
+        stop_response, _ = send_request(
+            process,
+            tool_request(18, "task_stop", {"pid": 99999, "grace_period": 1}),
+        )
+        assert_condition("error" in stop_response, "task_stop should error for bad pid", stop_response)
+        print("✓ nonexistent-job tools return MCP errors")
+        return True
+    finally:
+        stop_process(process)
+
+
+def test_logging_severity_classification():
+    print("Test 11: stderr logging notifications use info, warning, and error levels correctly")
+    process, _ = start_mcp_process()
+    try:
+        response, notifications = send_request(
+            process,
+            tool_request(
+                19,
+                "task_start",
+                {
+                    "unique_name": "stderr-level-task",
+                    "wait_for_exit_seconds": 3,
+                },
+            ),
+            timeout_seconds=10,
+        )
+        payload = parse_tool_result(response)
+        assert_condition(payload["state"] == "exited", "stderr-level-task should exit", payload)
+
+        logs = logging_notifications(notifications)
+        stderr_logs = [
+            log
+            for log in logs
+            if log.get("params", {}).get("data", {}).get("type") == "stderr"
+        ]
+        levels_by_line = {
+            log.get("params", {}).get("data", {}).get("line"): log.get("params", {}).get("level")
+            for log in stderr_logs
+        }
+
+        assert_condition(
+            levels_by_line.get("plain stderr line") == "info",
+            "plain stderr should log at info",
+            levels_by_line,
+        )
+        assert_condition(
+            levels_by_line.get("warning: this is a warning") == "warning",
+            "warning stderr should log at warning",
+            levels_by_line,
+        )
+        assert_condition(
+            levels_by_line.get("error: this is an error") == "error",
+            "error stderr should log at error",
+            levels_by_line,
+        )
+        print("✓ stderr notification levels are classified correctly")
+        return True
+    finally:
+        stop_process(process)
+
+
+def main():
+    tests = [
+        test_initialize_instructions,
+        test_tools_list_schema,
+        test_list_tasks_enriched_fields,
+        test_task_start_quick_exit,
+        test_task_start_args_and_spaces,
+        test_error_taxonomy,
+        test_bounded_wait_completion,
+        test_task_status_completion_metadata,
+        test_running_lifecycle_and_stop,
+        test_nonexistent_job_tools,
+        test_logging_severity_classification,
+    ]
+
     print("Starting MCP protocol integration tests...")
-    
-    # Test 1: Test MCP initialize handshake
-    print("Test 1: Testing MCP initialize handshake")
-    
-    # Start dela mcp process
-    cwd = "/home/testuser/test_project"
-    process = start_mcp_process(cwd)
-    
-    if process is None:
-        print("✗ MCP initialize handshake failed - could not start process")
-        return False
-    
-    try:
-        # The handshake is already done in start_mcp_process
-        print("✓ MCP initialize handshake works")
-        
-    except Exception as e:
-        print(f"✗ MCP initialize handshake error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 2: Test MCP tools/list
-    print("Test 2: Testing MCP tools/list")
-    
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP tools/list failed - could not start process")
-        return False
-    
-    try:
-        # Send tools/list request
-        tools_request = {
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/list",
-            "params": {}
-        }
-        
-        process.stdin.write(json.dumps(tools_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        if "list_tasks" in stdout and "task_start" in stdout:
-            print("✓ MCP tools/list works")
-        else:
-            print("✗ MCP tools/list failed")
-            print("STDOUT:", stdout)
-            print("STDERR:", stderr)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP tools/list timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP tools/list error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 3: Test MCP list_tasks
-    print("Test 3: Testing MCP list_tasks")
-    
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP list_tasks failed - could not start process")
-        return False
-    
-    try:
-        # Send list_tasks request
-        list_tasks_request = {
-            "jsonrpc": "2.0",
-            "id": 3,
-            "method": "tools/call",
-            "params": {
-                "name": "list_tasks",
-                "arguments": {}
-            }
-        }
-        
-        process.stdin.write(json.dumps(list_tasks_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        if "build" in stdout or "test" in stdout:
-            print("✓ MCP list_tasks works")
-        else:
-            print("✗ MCP list_tasks failed")
-            print("STDOUT:", stdout)
-            print("STDERR:", stderr)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP list_tasks timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP list_tasks error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 4: Test MCP status tool (DTKT-172)
-    print("Test 4: Testing MCP status tool (DTKT-172)")
-    
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP status tool failed - could not start process")
-        return False
-    
-    try:
-        # Send status request
-        status_request = {
-            "jsonrpc": "2.0",
-            "id": 4,
-            "method": "tools/call",
-            "params": {
-                "name": "status",
-                "arguments": {}
-            }
-        }
-        
-        process.stdin.write(json.dumps(status_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        # Parse JSON response to verify structure
+    for test in tests:
         try:
-            lines = stdout.strip().split('\n')
-            json_response = None
-            for line in lines:
-                if line.strip().startswith('{') and '"id":4' in line:
-                    json_response = json.loads(line)
-                    break
-            
-            if json_response and "result" in json_response:
-                result = json_response["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        status_data = json.loads(content["text"])
-                        if "running" in status_data and isinstance(status_data["running"], list):
-                            print("✓ MCP status tool works (returns running jobs array)")
-                        else:
-                            print("✗ MCP status tool failed - invalid response structure")
-                            print("STDOUT:", stdout)
-                            return False
-                    else:
-                        print("✗ MCP status tool failed - no text content")
-                        print("STDOUT:", stdout)
-                        return False
-                else:
-                    print("✗ MCP status tool failed - no content")
-                    print("STDOUT:", stdout)
-                    return False
-            else:
-                print("✗ MCP status tool failed - no result")
-                print("STDOUT:", stdout)
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP status tool failed - JSON decode error: {e}")
-            print("STDOUT:", stdout)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP status tool timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP status tool error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 5: Test MCP task_start quick execution
-    print("Test 5: Testing MCP task_start quick execution")
-    
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP task_start quick execution failed - could not start process")
-        return False
-    
-    try:
-        # Send task_start request for a quick task
-        task_start_request = {
-            "jsonrpc": "2.0",
-            "id": 5,
-            "method": "tools/call",
-            "params": {
-                "name": "task_start",
-                "arguments": {
-                    "unique_name": "test-task"
-                }
-            }
-        }
-        
-        process.stdin.write(json.dumps(task_start_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(3)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        if "ok" in stdout and "result" in stdout:
-            print("✓ MCP task_start quick execution works")
-        else:
-            print("✗ MCP task_start quick execution failed")
-            print("STDOUT:", stdout)
-            print("STDERR:", stderr)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP task_start quick execution timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP task_start quick execution error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
+            if not test():
+                return 1
+        except Exception as exc:
+            return 1 if fail(f"{test.__name__} failed: {exc}") else 1
 
-    # Test 6: Test MCP task_start with arguments
-    print("Test 6: Testing MCP task_start with arguments")
-    
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP task_start with arguments failed - could not start process")
-        return False
-    
-    try:
-        # Send task_start request with arguments
-        task_start_request = {
-            "jsonrpc": "2.0",
-            "id": 6,
-            "method": "tools/call",
-            "params": {
-                "name": "task_start",
-                "arguments": {
-                    "unique_name": "print-args",
-                    "args": ["--verbose", "--debug"]
-                }
-            }
-        }
-        
-        process.stdin.write(json.dumps(task_start_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(3)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        if "ok" in stdout and "result" in stdout:
-            print("✓ MCP task_start with arguments works")
-        else:
-            print("✗ MCP task_start with arguments failed")
-            print("STDOUT:", stdout)
-            print("STDERR:", stderr)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP task_start with arguments timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP task_start with arguments error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-
-    # Test 6b: Test MCP task_start with arguments that include spaces
-    print("Test 6b: Testing MCP task_start with space-containing arguments")
-
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP task_start with spaced args failed - could not start process")
-        return False
-
-    try:
-        spaced_args_request = {
-            "jsonrpc": "2.0",
-            "id": 65,
-            "method": "tools/call",
-            "params": {
-                "name": "task_start",
-                "arguments": {
-                    "unique_name": "print-args",
-                    "args": ["ARGS=value with spaces"]
-                }
-            }
-        }
-
-        response = send_request(process, spaced_args_request)
-
-        if "result" in response:
-            content = response["result"].get("content", [])
-            if content and "text" in content[0]:
-                try:
-                    payload = json.loads(content[0]["text"])
-                    if payload.get("ok") and "result" in payload:
-                        initial_output = payload["result"].get("initial_output", "")
-                        if "value with spaces" in initial_output:
-                            print("✓ MCP task_start preserves arguments with spaces")
-                        else:
-                            print("✗ MCP task_start did not preserve spaced argument")
-                            print(f"Initial output: {initial_output}")
-                            return False
-                    else:
-                        print("✗ MCP task_start spaced args response missing ok/result")
-                        return False
-                except json.JSONDecodeError as e:
-                    print(f"✗ MCP task_start spaced args response not JSON: {e}")
-                    return False
-            else:
-                print("✗ MCP task_start spaced args missing text content")
-                return False
-        else:
-            print("✗ MCP task_start spaced args missing result")
-            return False
-    except Exception as e:
-        print(f"✗ MCP task_start with spaced args error: {e}")
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-
-    # Test 7: Test MCP error taxonomy - TaskNotFound
-    print("Test 7: Testing MCP error taxonomy - TaskNotFound")
-    
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP error taxonomy - TaskNotFound failed - could not start process")
-        return False
-    
-    try:
-        # Send task_start request for non-existent task
-        task_start_request = {
-            "jsonrpc": "2.0",
-            "id": 7,
-            "method": "tools/call",
-            "params": {
-                "name": "task_start",
-                "arguments": {
-                    "unique_name": "nonexistent-task"
-                }
-            }
-        }
-        
-        process.stdin.write(json.dumps(task_start_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        if "error" in stdout and "not found" in stdout:
-            print("✓ MCP error taxonomy - TaskNotFound works")
-        else:
-            print("✗ MCP error taxonomy - TaskNotFound failed")
-            print("STDOUT:", stdout)
-            print("STDERR:", stderr)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP error taxonomy - TaskNotFound timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP error taxonomy - TaskNotFound error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 8: Test MCP error taxonomy - NotAllowlisted
-    print("Test 8: Testing MCP error taxonomy - NotAllowlisted")
-    
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP error taxonomy - NotAllowlisted failed - could not start process")
-        return False
-    
-    try:
-        # Send task_start request for task not in allowlist
-        task_start_request = {
-            "jsonrpc": "2.0",
-            "id": 8,
-            "method": "tools/call",
-            "params": {
-                "name": "task_start",
-                "arguments": {
-                    "unique_name": "custom-exe"  # This task exists but is not in allowlist
-                }
-            }
-        }
-        
-        process.stdin.write(json.dumps(task_start_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        if "error" in stdout and ("not allowlisted" in stdout or "NotAllowlisted" in stdout):
-            print("✓ MCP error taxonomy - NotAllowlisted works")
-        else:
-            print("✗ MCP error taxonomy - NotAllowlisted failed")
-            print("STDOUT:", stdout)
-            print("STDERR:", stderr)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP error taxonomy - NotAllowlisted timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP error taxonomy - NotAllowlisted error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 9: Test MCP list_tasks enriched fields
-    print("Test 9: Testing MCP list_tasks enriched fields")
-    
-    process = start_mcp_process(cwd)
-    if process is None:
-        print("✗ MCP list_tasks enriched fields failed - could not start process")
-        return False
-    
-    try:
-        # Send list_tasks request
-        list_tasks_request = {
-            "jsonrpc": "2.0",
-            "id": 9,
-            "method": "tools/call",
-            "params": {
-                "name": "list_tasks",
-                "arguments": {}
-            }
-        }
-        
-        process.stdin.write(json.dumps(list_tasks_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        # Check for enriched fields in the response
-        if ("unique_name" in stdout and "source_name" in stdout and 
-            "runner" in stdout and "command" in stdout and 
-            "runner_available" in stdout and "allowlisted" in stdout and 
-            "file_path" in stdout):
-            print("✓ MCP list_tasks enriched fields work")
-        else:
-            print("✗ MCP list_tasks enriched fields failed")
-            print("STDOUT:", stdout)
-            print("STDERR:", stderr)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP list_tasks enriched fields timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP list_tasks enriched fields error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 10: Test MCP task_status tool (DTKT-173)
-    print("Test 10: Testing MCP task_status tool (DTKT-173)")
-    
-    process = start_mcp_process(cwd)
-    
-    try:
-        # Send task_status request for a non-existent task
-        task_status_request = {
-            "jsonrpc": "2.0",
-            "id": 10,
-            "method": "tools/call",
-            "params": {
-                "name": "task_status",
-                "arguments": {
-                    "unique_name": "nonexistent-task"
-                }
-            }
-        }
-        
-        process.stdin.write(json.dumps(task_status_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        # Parse JSON response to verify structure
-        try:
-            lines = stdout.strip().split('\n')
-            json_response = None
-            for line in lines:
-                if line.strip().startswith('{') and '"id":10' in line:
-                    json_response = json.loads(line)
-                    break
-            
-            if json_response and "result" in json_response:
-                result = json_response["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        status_data = json.loads(content["text"])
-                        if "jobs" in status_data and isinstance(status_data["jobs"], list):
-                            print("✓ MCP task_status tool works (returns jobs array)")
-                        else:
-                            print("✗ MCP task_status tool failed - invalid response structure")
-                            print("STDOUT:", stdout)
-                            return False
-                    else:
-                        print("✗ MCP task_status tool failed - no text content")
-                        print("STDOUT:", stdout)
-                        return False
-                else:
-                    print("✗ MCP task_status tool failed - no content")
-                    print("STDOUT:", stdout)
-                    return False
-            else:
-                print("✗ MCP task_status tool failed - no result")
-                print("STDOUT:", stdout)
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP task_status tool failed - JSON decode error: {e}")
-            print("STDOUT:", stdout)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP task_status tool timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP task_status tool error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 11: Test MCP task_output tool (DTKT-174)
-    print("Test 11: Testing MCP task_output tool (DTKT-174)")
-    
-    process = start_mcp_process(cwd)
-    
-    try:
-        # Send task_output request for a non-existent job
-        task_output_request = {
-            "jsonrpc": "2.0",
-            "id": 11,
-            "method": "tools/call",
-            "params": {
-                "name": "task_output",
-                "arguments": {
-                    "pid": 99999,
-                    "lines": 10,
-                    "show_truncation": True
-                }
-            }
-        }
-        
-        process.stdin.write(json.dumps(task_output_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        # Parse JSON response to verify structure
-        try:
-            lines = stdout.strip().split('\n')
-            json_response = None
-            for line in lines:
-                if line.strip().startswith('{') and '"id":11' in line:
-                    json_response = json.loads(line)
-                    break
-            
-            if json_response and "error" in json_response:
-                # Expected error for non-existent job
-                print("✓ MCP task_output tool works (returns error for non-existent job)")
-            elif json_response and "result" in json_response:
-                result = json_response["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        output_data = json.loads(content["text"])
-                        if ("pid" in output_data and "lines" in output_data and 
-                            "total_lines" in output_data and "truncated" in output_data):
-                            print("✓ MCP task_output tool works (returns output structure)")
-                        else:
-                            print("✗ MCP task_output tool failed - invalid response structure")
-                            print("STDOUT:", stdout)
-                            return False
-                    else:
-                        print("✗ MCP task_output tool failed - no text content")
-                        print("STDOUT:", stdout)
-                        return False
-                else:
-                    print("✗ MCP task_output tool failed - no content")
-                    print("STDOUT:", stdout)
-                    return False
-            else:
-                print("✗ MCP task_output tool failed - no result or error")
-                print("STDOUT:", stdout)
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP task_output tool failed - JSON decode error: {e}")
-            print("STDOUT:", stdout)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP task_output tool timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP task_output tool error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 12: Test MCP task_stop tool (DTKT-175)
-    print("Test 12: Testing MCP task_stop tool (DTKT-175)")
-    
-    process = start_mcp_process(cwd)
-    
-    try:
-        # Send task_stop request for a non-existent job
-        task_stop_request = {
-            "jsonrpc": "2.0",
-            "id": 12,
-            "method": "tools/call",
-            "params": {
-                "name": "task_stop",
-                "arguments": {
-                    "pid": 99999,
-                    "grace_period": 5
-                }
-            }
-        }
-        
-        process.stdin.write(json.dumps(task_stop_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        time.sleep(2)
-        
-        # Read response
-        stdout, stderr = process.communicate(timeout=5)
-        
-        # Parse JSON response to verify structure
-        try:
-            lines = stdout.strip().split('\n')
-            json_response = None
-            for line in lines:
-                if line.strip().startswith('{') and '"id":12' in line:
-                    json_response = json.loads(line)
-                    break
-            
-            if json_response and "error" in json_response:
-                # Expected error for non-existent job
-                print("✓ MCP task_stop tool works (returns error for non-existent job)")
-            elif json_response and "result" in json_response:
-                result = json_response["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        stop_data = json.loads(content["text"])
-                        if ("pid" in stop_data and "status" in stop_data and 
-                            "message" in stop_data and "grace_period_used" in stop_data):
-                            print("✓ MCP task_stop tool works (returns stop structure)")
-                        else:
-                            print("✗ MCP task_stop tool failed - invalid response structure")
-                            print("STDOUT:", stdout)
-                            return False
-                    else:
-                        print("✗ MCP task_stop tool failed - no text content")
-                        print("STDOUT:", stdout)
-                        return False
-                else:
-                    print("✗ MCP task_stop tool failed - no content")
-                    print("STDOUT:", stdout)
-                    return False
-            else:
-                print("✗ MCP task_stop tool failed - no result or error")
-                print("STDOUT:", stdout)
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP task_stop tool failed - JSON decode error: {e}")
-            print("STDOUT:", stdout)
-            return False
-            
-    except subprocess.TimeoutExpired:
-        print("✗ MCP task_stop tool timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP task_stop tool error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
-    # Test 13: Test MCP long-running task lifecycle (task_start, status, task_status)
-    print("Test 13: Testing MCP long-running task lifecycle")
-    
-    process = start_mcp_process(cwd)
-    
-    try:
-        # Send task_start request for long-running task
-        task_start_request = {
-            "jsonrpc": "2.0",
-            "id": 13,
-            "method": "tools/call",
-            "params": {
-                "name": "task_start",
-                "arguments": {
-                    "unique_name": "long-running-task"
-                }
-            }
-        }
-        
-        print("Sending task_start request for long-running task...")
-        task_start_response = send_request(process, task_start_request)
-        print(f"Task start response: {json.dumps(task_start_response)}")
-        
-        # Parse task_start response to get PID
-        try:
-            if "result" in task_start_response:
-                result = task_start_response["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        start_data = json.loads(content["text"])
-                        if "ok" in start_data and start_data["ok"] and "result" in start_data:
-                            task_result = start_data["result"]
-                            if "pid" in task_result and "state" in task_result:
-                                pid = task_result["pid"]
-                                state = task_result["state"]
-                                if state == "running":
-                                    print("✓ MCP task_start for long-running task works")
-                                else:
-                                    print(f"✗ MCP task_start failed - task not running: {state}")
-                                    return False
-                                
-                                # NEW: call task_output to verify initial lines are captured
-                                task_output_request = {
-                                    "jsonrpc": "2.0",
-                                    "id": 13_1,
-                                    "method": "tools/call",
-                                    "params": {
-                                        "name": "task_output",
-                                        "arguments": {
-                                            "pid": pid,
-                                            "lines": 50,
-                                            "show_truncation": True
-                                        }
-                                    }
-                                }
-                                # Give a short moment for output to be stored
-                                time.sleep(0.3)
-                                print("Requesting task_output for long-running task...")
-                                task_output_response = send_request(process, task_output_request)
-                                print(f"Task output response: {json.dumps(task_output_response)}")
-                                if "result" in task_output_response:
-                                    out_res = task_output_response["result"]
-                                    if "content" in out_res and len(out_res["content"]) > 0:
-                                        out_content = out_res["content"][0]
-                                        if "text" in out_content:
-                                            out_json = json.loads(out_content["text"])
-                                            # Basic assertions on structure
-                                            assert out_json.get("pid") == pid
-                                            lines = out_json.get("lines", [])
-                                            assert isinstance(lines, list)
-                                            # We expect at least the first echo to be present
-                                            # Some environments may buffer differently; accept any non-empty
-                                            if not lines:
-                                                print("✗ task_output returned no lines")
-                                                return False
-                                            else:
-                                                print("✓ task_output returned lines (captured initial output)")
-                                        else:
-                                            print("✗ task_output missing text content")
-                                            return False
-                                    else:
-                                        print("✗ task_output missing content")
-                                        return False
-                                else:
-                                    print("✗ task_output missing result")
-                                    return False
-
-                                # NEW: stop while running
-                                task_stop_request = {
-                                    "jsonrpc": "2.0",
-                                    "id": 1312,
-                                    "method": "tools/call",
-                                    "params": {
-                                        "name": "task_stop",
-                                        "arguments": {"pid": pid, "grace_period": 2}
-                                    }
-                                }
-                                print("Sending task_stop request for long-running task (while running)...")
-                                task_stop_response = send_request(process, task_stop_request)
-                                print(f"Task stop response: {json.dumps(task_stop_response)}")
-                                if "result" in task_stop_response:
-                                    stop_res = task_stop_response["result"]
-                                    if "content" in stop_res and len(stop_res["content"]) > 0:
-                                        stop_content = stop_res["content"][0]
-                                        if "text" in stop_content:
-                                            stop_json = json.loads(stop_content["text"])
-                                            assert stop_json.get("pid") == pid
-                                            assert stop_json.get("status") in ("graceful", "killed", "failed")
-                                            print("✓ MCP task_stop returned valid structure (stopped while running)")
-                                        else:
-                                            print("✗ task_stop missing text content")
-                                            return False
-                                    else:
-                                        print("✗ task_stop missing content")
-                                        return False
-                                else:
-                                    print("✗ task_stop missing result")
-                                    return False
-                            else:
-                                print("✗ MCP task_start failed - missing pid or state")
-                                return False
-                        else:
-                            print("✗ MCP task_start failed - not ok or missing result")
-                            print(f"Start data: {start_data}")
-                            return False
-                    else:
-                        print("✗ MCP task_start failed - no text content")
-                        return False
-                else:
-                    print("✗ MCP task_start failed - no content")
-                    return False
-            else:
-                print("✗ MCP task_start failed - no result")
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP task_start failed - JSON decode error: {e}")
-            return False
-        
-        # Wait a moment for the job to be registered
-        time.sleep(1)
-        
-        # Test status tool - should show the running task
-        status_request = {
-            "jsonrpc": "2.0",
-            "id": 14,
-            "method": "tools/call",
-            "params": {
-                "name": "status",
-                "arguments": {}
-            }
-        }
-        
-        print("Sending status request...")
-        status_response = send_request(process, status_request)
-        print(f"Status response: {json.dumps(status_response)}")
-        
-        # Parse status response
-        try:
-            if "result" in status_response:
-                result = status_response["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        status_data = json.loads(content["text"])
-                        if "running" in status_data and isinstance(status_data["running"], list):
-                            running_jobs = status_data["running"]
-                            # After stopping the task, there should be no running jobs
-                            if len(running_jobs) == 0:
-                                print("✓ MCP status tool shows no running jobs (task was stopped)")
-                            else:
-                                # Check if our stopped task is still in the running jobs (it shouldn't be)
-                                found_task = False
-                                for job in running_jobs:
-                                    if job.get("unique_name") == "long-running-task" and job.get("pid") == pid:
-                                        found_task = True
-                                        break
-                                if found_task:
-                                    print("✗ MCP status tool failed - stopped task still shows as running")
-                                    return False
-                                else:
-                                    print("✓ MCP status tool shows running jobs but not the stopped task")
-                        else:
-                            print("✗ MCP status tool failed - invalid response structure")
-                            return False
-                    else:
-                        print("✗ MCP status tool failed - no text content")
-                        return False
-                else:
-                    print("✗ MCP status tool failed - no content")
-                    return False
-            else:
-                print("✗ MCP status tool failed - no result")
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP status tool failed - JSON decode error: {e}")
-            return False
-        
-        # Test task_status tool - should show the running task
-        task_status_request = {
-            "jsonrpc": "2.0",
-            "id": 15,
-            "method": "tools/call",
-            "params": {
-                "name": "task_status",
-                "arguments": {
-                    "unique_name": "long-running-task"
-                }
-            }
-        }
-        
-        print("Sending task_status request...")
-        task_status_response = send_request(process, task_status_request)
-        print(f"Task status response: {json.dumps(task_status_response)}")
-        
-        # Parse task_status response
-        try:
-            if "result" in task_status_response:
-                result = task_status_response["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        status_data = json.loads(content["text"])
-                        if "jobs" in status_data and isinstance(status_data["jobs"], list):
-                            jobs = status_data["jobs"]
-                            if len(jobs) > 0:
-                                # Check if our task is in the jobs
-                                found_task = False
-                                for job in jobs:
-                                    if job.get("unique_name") == "long-running-task" and job.get("pid") == pid:
-                                        # After stopping the task, it should be in a stopped state (not running)
-                                        if job.get("state") in ("failed", "exited", "stopped", "killed"):
-                                            found_task = True
-                                            print(f"✓ MCP task_status tool shows stopped task with state: {job.get('state')}")
-                                            break
-                                        else:
-                                            print(f"✗ MCP task_status tool failed - unexpected task state: {job.get('state')}")
-                                            return False
-                                if not found_task:
-                                    print("✗ MCP task_status tool failed - long-running task not found in jobs")
-                                    return False
-                            else:
-                                print("✗ MCP task_status tool failed - no jobs found")
-                                return False
-                        else:
-                            print("✗ MCP task_status tool failed - invalid response structure")
-                            return False
-                    else:
-                        print("✗ MCP task_status tool failed - no text content")
-                        return False
-                else:
-                    print("✗ MCP task_status tool failed - no content")
-                    return False
-            else:
-                print("✗ MCP task_status tool failed - no result")
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP task_status tool failed - JSON decode error: {e}")
-            return False
-        
-        # Wait for the task to complete (it runs for 5 seconds)
-        print("Waiting for long-running task to complete...")
-        time.sleep(6)
-        
-        # Test status tool again - should show no running tasks
-        status_request2 = {
-            "jsonrpc": "2.0",
-            "id": 16,
-            "method": "tools/call",
-            "params": {
-                "name": "status",
-                "arguments": {}
-            }
-        }
-        
-        print("Sending status request after completion...")
-        status_response2 = send_request(process, status_request2)
-        print(f"Status response (after completion): {json.dumps(status_response2)}")
-        
-        # Parse status response
-        try:
-            if "result" in status_response2:
-                result = status_response2["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        status_data = json.loads(content["text"])
-                        if "running" in status_data and isinstance(status_data["running"], list):
-                            running_jobs = status_data["running"]
-                            if len(running_jobs) == 0:
-                                print("✓ MCP status tool shows no running tasks after completion")
-                            else:
-                                print(f"✗ MCP status tool failed - still shows {len(running_jobs)} running jobs after completion")
-                                return False
-                        else:
-                            print("✗ MCP status tool failed - invalid response structure")
-                            return False
-                    else:
-                        print("✗ MCP status tool failed - no text content")
-                        return False
-                else:
-                    print("✗ MCP status tool failed - no content")
-                    return False
-            else:
-                print("✗ MCP status tool failed - no result")
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP status tool failed - JSON decode error: {e}")
-            return False
-        
-        # Test task_status tool again - should show completed task
-        task_status_request2 = {
-            "jsonrpc": "2.0",
-            "id": 17,
-            "method": "tools/call",
-            "params": {
-                "name": "task_status",
-                "arguments": {
-                    "unique_name": "long-running-task"
-                }
-            }
-        }
-        
-        print("Sending task_status request after completion...")
-        task_status_response2 = send_request(process, task_status_request2)
-        print(f"Task status response (after completion): {json.dumps(task_status_response2)}")
-        
-        # Parse task_status response
-        try:
-            if "result" in task_status_response2:
-                result = task_status_response2["result"]
-                if "content" in result and len(result["content"]) > 0:
-                    content = result["content"][0]
-                    if "text" in content:
-                        status_data = json.loads(content["text"])
-                        if "jobs" in status_data and isinstance(status_data["jobs"], list):
-                            jobs = status_data["jobs"]
-                            if len(jobs) > 0:
-                                # Check if our task is in the jobs and completed
-                                found_task = False
-                                for job in jobs:
-                                    if job.get("unique_name") == "long-running-task" and job.get("pid") == pid:
-                                        if job.get("state") == "exited":
-                                            found_task = True
-                                            print("✓ MCP task_status tool shows completed long-running task")
-                                            break
-                                        else:
-                                            print(f"✗ MCP task_status tool failed - task not exited: {job.get('state')}")
-                                            return False
-                                if not found_task:
-                                    print("✗ MCP task_status tool failed - long-running task not found in jobs after completion")
-                                    return False
-                            else:
-                                print("✗ MCP task_status tool failed - no jobs found after completion")
-                                return False
-                        else:
-                            print("✗ MCP task_status tool failed - invalid response structure")
-                            return False
-                    else:
-                        print("✗ MCP task_status tool failed - no text content")
-                        return False
-                else:
-                    print("✗ MCP task_status tool failed - no content")
-                    return False
-            else:
-                print("✗ MCP task_status tool failed - no result")
-                return False
-        except json.JSONDecodeError as e:
-            print(f"✗ MCP task_status tool failed - JSON decode error: {e}")
-            return False
-        
-        # Stop the running task via task_stop and validate
-        task_stop_request = {
-            "jsonrpc": "2.0",
-            "id": 18,
-            "method": "tools/call",
-            "params": {
-                "name": "task_stop",
-                "arguments": {
-                    "pid": pid,
-                    "grace_period": 2
-                }
-            }
-        }
-        print("Sending task_stop request for long-running task...")
-        task_stop_response = send_request(process, task_stop_request)
-        print(f"Task stop response: {json.dumps(task_stop_response)}")
-
-        if "result" in task_stop_response:
-            stop_res = task_stop_response["result"]
-            if "content" in stop_res and len(stop_res["content"]) > 0:
-                stop_content = stop_res["content"][0]
-                if "text" in stop_content:
-                    stop_json = json.loads(stop_content["text"])
-                    assert stop_json.get("pid") == pid
-                    assert stop_json.get("status") in ("graceful", "killed", "failed")
-                    print("✓ MCP task_stop returned valid structure")
-                else:
-                    print("✗ task_stop missing text content")
-                    return False
-            else:
-                print("✗ task_stop missing content")
-                return False
-        elif "error" in task_stop_response:
-            # Expected: trying to stop an already completed task should return an error
-            error = task_stop_response["error"]
-            if "message" in error and "not running" in error["message"]:
-                print("✓ MCP task_stop correctly returned error for already completed task")
-            else:
-                print(f"✗ MCP task_stop returned unexpected error: {error}")
-                return False
-        else:
-            print("✗ task_stop missing result and error")
-            return False
-
-        # After stopping, status should show no running jobs for that pid
-        status_after_stop = send_request(process, status_request)
-        print(f"Status after stop: {json.dumps(status_after_stop)}")
-        if "result" in status_after_stop:
-            res = status_after_stop["result"]
-            content = res.get("content", [])
-            if content:
-                text = json.loads(content[0].get("text", "{}"))
-                running = text.get("running", [])
-                still_running = any(j.get("pid") == pid for j in running)
-                if still_running:
-                    print("✗ task still running after task_stop")
-                    return False
-                else:
-                    print("✓ task_stop removed task from running list")
-            else:
-                print("✗ status after stop missing content")
-                return False
-
-        print("✓ MCP long-running task lifecycle test passed!")
-        
-    except subprocess.TimeoutExpired:
-        print("✗ MCP long-running task lifecycle test timed out")
-        process.kill()
-        return False
-    except Exception as e:
-        print(f"✗ MCP long-running task lifecycle test error: {e}")
-        process.kill()
-        return False
-    finally:
-        if process.poll() is None:
-            process.kill()
-    
     print("✓ All MCP protocol integration tests passed!")
-    return True
+    return 0
+
 
 if __name__ == "__main__":
-    success = test_mcp_protocol()
-    sys.exit(0 if success else 1)
+    sys.exit(main())

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -531,26 +531,36 @@ def test_logging_severity_classification():
             for log in logs
             if log.get("params", {}).get("data", {}).get("type") == "stderr"
         ]
-        levels_by_line = {
-            log.get("params", {}).get("data", {}).get("line"): log.get("params", {}).get("level")
-            for log in stderr_logs
-        }
+        assert_condition(
+            len(stderr_logs) == 1,
+            "stderr fixture should be delivered as one batched notification",
+            stderr_logs,
+        )
+        batch = stderr_logs[0].get("params", {}).get("data", {})
+        lines = batch.get("lines", [])
+        batch_level = stderr_logs[0].get("params", {}).get("level")
 
         assert_condition(
-            levels_by_line.get("plain stderr line") == "info",
-            "plain stderr should log at info",
-            levels_by_line,
+            "plain stderr line" in lines,
+            "plain stderr line missing from batch",
+            batch,
         )
         assert_condition(
-            levels_by_line.get("warning: this is a warning") == "warning",
-            "warning stderr should log at warning",
-            levels_by_line,
+            "warning: this is a warning" in lines,
+            "warning stderr line missing from batch",
+            batch,
         )
         assert_condition(
-            levels_by_line.get("error: this is an error") == "error",
-            "error stderr should log at error",
-            levels_by_line,
+            "error: this is an error" in lines,
+            "error stderr line missing from batch",
+            batch,
         )
+        assert_condition(batch_level == "error", "batch severity should escalate to error", stderr_logs[0])
+        assert_condition("line" not in batch, "batched payload should not include singular line", batch)
+        assert_condition("entries" not in batch, "batched payload should not include per-line entries", batch)
+        assert_condition("chunk" not in batch, "batched payload should not include chunk", batch)
+        assert_condition("byte_count" not in batch, "batched payload should not include byte_count", batch)
+        assert_condition("line_count" not in batch, "batched payload should not include line_count", batch)
         print("✓ stderr notification levels are classified correctly")
         return True
     finally:

--- a/tests/task_definitions/Makefile
+++ b/tests/task_definitions/Makefile
@@ -1,6 +1,6 @@
 # Test Makefile for dela Docker tests
 
-.PHONY: test-task another-task help cd custom-exe print-args test long-running-task
+.PHONY: test-task another-task help cd custom-exe print-args test long-running-task stderr-level-task
 
 test-task: ## Test task for basic functionality
 	@echo "Test task executed successfully"
@@ -15,6 +15,11 @@ long-running-task: ## Long running task for testing background execution
 	@echo "Starting long-running task..."
 	@sleep 5
 	@echo "Long-running task completed successfully"
+
+stderr-level-task: ## Emit stderr lines for MCP logging level classification
+	@printf '%s\n' 'plain stderr line' >&2
+	@printf '%s\n' 'warning: this is a warning' >&2
+	@printf '%s\n' 'error: this is an error' >&2
 
 print-arg-task: ## Test task for basic functionality with args
 	@echo "Argument is: $(ARG)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional configurable bounded wait-for-exit for MCP tasks; quicker quick-exit responses and richer task status (elapsed, exit code, completed timestamp)
  * Task discovery caching to improve MCP responsiveness
  * Batched log notifications with severity classification

* **Bug Fixes / UX**
  * MCP startup surfaces a clear "not ready" error with a hint to run dela init
  * CMake tasks are disabled for MCP execution; clearer tool-specific hints for missing runtimes

* **Documentation**
  * README and MCP design docs updated with init, framing, API examples, and CLI ergonomics

* **Tests**
  * Reworked JSON-RPC integration tests and new stderr-level task fixture
<!-- end of auto-generated comment: release notes by coderabbit.ai -->