### PR TITLE
Adding --color=always option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build tests tests_integration test_unit test_noinit test_mcp test_zsh test_bash test_fish test_pwsh run install builder
+.PHONY: build tests tests_integration test_unit test_noinit test_mcp test_zsh test_bash test_fish test_pwsh run install
 
 SHELL := /bin/bash
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build tests tests_integration test_unit test_noinit test_mcp test_zsh test_bash test_fish test_pwsh run install builder publish
+.PHONY: build tests tests_integration test_unit test_noinit test_mcp test_zsh test_bash test_fish test_pwsh run install builder
 
 SHELL := /bin/bash
 
@@ -67,15 +67,6 @@ inspect_mcp:
 	# Avoid any stdout noise; Inspector expects clean MCP JSON-RPC on stdout.
 	MCPI_NO_COLOR=1 RUST_LOG=warn RUSTFLAGS="-A warnings" npx @modelcontextprotocol/inspector ./target/debug/dela mcp --cwd $(PWD)
 
-
-# Publish to crates.io. Deprecated. Will be removed once 0.0.7 is released sucessfully using the new release process.
-publish: tests tests_integration
-	@echo "Publishing dela to crates.io"
-	@if [ -z "$(CARGO_REGISTRY_TOKEN)" ]; then \
-		echo "Error: CARGO_REGISTRY_TOKEN is not set. Please add it to your .env file."; \
-		exit 1; \
-	fi
-	@cargo publish
 format:
 	cargo fmt --all
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -17,7 +17,13 @@ macro_rules! test_println {
     ($($arg:tt)*) => { println!($($arg)*) };
 }
 
-pub fn execute(verbose: bool) -> anyhow::Result<()> {
+pub fn execute(verbose: bool, color: &str) -> anyhow::Result<()> {
+    match color {
+        "always" => colored::control::set_override(true),
+        "never" => colored::control::set_override(false),
+        _ => {}
+    }
+
     let current_dir = env::current_dir()
         .map_err(|e| anyhow::anyhow!("Failed to get current directory: {}", e))?;
     let discovered = task_discovery::discover_tasks(&current_dir);

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -21,7 +21,7 @@ pub fn execute(verbose: bool, color: &str) -> anyhow::Result<()> {
     match color {
         "always" => colored::control::set_override(true),
         "never" => colored::control::set_override(false),
-        _ => {}
+        _ => colored::control::unset_override(),
     }
 
     let current_dir = env::current_dir()

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,10 @@ enum Commands {
         /// Show detailed information about task definition files
         #[arg(short, long)]
         verbose: bool,
+
+        /// Control colored output (always, auto, never)
+        #[arg(long, default_value = "auto")]
+        color: String,
     },
 
     /// Run a specific task
@@ -180,7 +184,7 @@ async fn main() {
         }
         Commands::Init => commands::init::execute(),
         Commands::ConfigureShell => commands::configure_shell::execute(),
-        Commands::List { verbose } => commands::list::execute(verbose),
+        Commands::List { verbose, color } => commands::list::execute(verbose, &color),
         Commands::Run { task } => commands::run::execute(&task),
         Commands::GetCommand { args } => {
             if args.is_empty() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `list` command now supports a `--color` option to control colored output in results (supports "auto", "always", and "never" options).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aleyan/dela/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->