### PR TITLE
Adding CRAP metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tests/task_definitions/build/*
 .cursor
 /scratch
 release_notes.md
+lcov.info

--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,8 @@ test_long:
 coverage_github: build
 	@echo "Running parsing coverage over top github repos..."
 	uv run --script scripts/dela_coverage_git_refs.py --dela-bin ./target/debug/dela
+
+cargo_crap:
+	@echo "Reporting Change Risk Anti-Patterns metric"
+	cargo llvm-cov --lcov --output-path lcov.info
+	cargo crap --lcov lcov.info

--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,8 @@ coverage_github: build
 
 cargo_crap:
 	@echo "Reporting Change Risk Anti-Patterns metric"
+	@echo "Checking dependencies (cargo-llvm-cov and cargo-crap)..."
+	@cargo llvm-cov --version 2>/dev/null | grep -q "0.8.7" || cargo install cargo-llvm-cov --version 0.8.7 --force --locked
+	@cargo crap --version 2>/dev/null | grep -q "0.2.0" || cargo install cargo-crap --version 0.2.0 --force --locked
 	cargo llvm-cov --lcov --output-path lcov.info
-	cargo crap --lcov lcov.info
+	cargo crap --lcov lcov.info --top 20

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ VERBOSE ?= 0
 -include .env
 
 include make/release.mk
+include make/crap.mk
 
 build:
 	@echo "Building dela..."
@@ -79,11 +80,3 @@ test_long:
 coverage_github: build
 	@echo "Running parsing coverage over top github repos..."
 	uv run --script scripts/dela_coverage_git_refs.py --dela-bin ./target/debug/dela
-
-cargo_crap:
-	@echo "Reporting Change Risk Anti-Patterns metric"
-	@echo "Checking dependencies (cargo-llvm-cov and cargo-crap)..."
-	@cargo llvm-cov --version 2>/dev/null | grep -q "0.8.7" || cargo install cargo-llvm-cov --version 0.8.7 --force --locked
-	@cargo crap --version 2>/dev/null | grep -q "0.2.0" || cargo install cargo-crap --version 0.2.0 --force --locked
-	cargo llvm-cov --lcov --output-path lcov.info
-	cargo crap --lcov lcov.info --top 20

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -1,0 +1,2454 @@
+{
+  "$schema": "https://raw.githubusercontent.com/minikin/cargo-crap/main/schemas/report-v1.json",
+  "version": "0.2.0",
+  "entries": [
+    {
+      "file": "./src/commands/list.rs",
+      "function": "execute",
+      "line": 20,
+      "cyclomatic": 72.0,
+      "coverage": 0.0,
+      "crap": 5256.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "execute",
+      "line": 243,
+      "cyclomatic": 19.0,
+      "coverage": 0.0,
+      "crap": 380.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::stop_job_graceful",
+      "line": 439,
+      "cyclomatic": 29.0,
+      "coverage": 24.691358024691358,
+      "crap": 388.19513360843445
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::call_tool",
+      "line": 1265,
+      "cyclomatic": 13.0,
+      "coverage": 0.0,
+      "crap": 182.0
+    },
+    {
+      "file": "./src/prompt.rs",
+      "function": "run_tui",
+      "line": 106,
+      "cyclomatic": 13.0,
+      "coverage": 0.0,
+      "crap": 182.0
+    },
+    {
+      "file": "./src/main.rs",
+      "function": "main",
+      "line": 163,
+      "cyclomatic": 11.0,
+      "coverage": 0.0,
+      "crap": 132.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_start",
+      "line": 414,
+      "cyclomatic": 43.0,
+      "coverage": 69.86899563318777,
+      "crap": 93.57987320997631
+    },
+    {
+      "file": "./src/prompt.rs",
+      "function": "prompt_for_task",
+      "line": 25,
+      "cyclomatic": 11.0,
+      "coverage": 27.27272727272727,
+      "crap": 57.54545454545455
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::garbage_collect",
+      "line": 633,
+      "cyclomatic": 8.0,
+      "coverage": 22.22222222222222,
+      "crap": 38.1124828532236
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::stop_job",
+      "line": 416,
+      "cyclomatic": 5.0,
+      "coverage": 0.0,
+      "crap": 30.0
+    },
+    {
+      "file": "./src/parsers/parse_pyproject_toml.rs",
+      "function": "parse",
+      "line": 7,
+      "cyclomatic": 29.0,
+      "coverage": 93.75,
+      "crap": 29.205322265625
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "normalize_path",
+      "line": 93,
+      "cyclomatic": 15.0,
+      "coverage": 68.96551724137932,
+      "crap": 21.72536799376768
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "strip_trailing_comment",
+      "line": 198,
+      "cyclomatic": 11.0,
+      "coverage": 56.25,
+      "crap": 21.132568359375
+    },
+    {
+      "file": "./src/types.rs",
+      "function": "TaskRunner::get_command",
+      "line": 199,
+      "cyclomatic": 21.0,
+      "coverage": 100.0,
+      "crap": 21.0
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "collect_turbo_tasks_for_context",
+      "line": 86,
+      "cyclomatic": 14.0,
+      "coverage": 68.11594202898551,
+      "crap": 20.352970542663975
+    },
+    {
+      "file": "./src/parsers/parse_travis_ci.rs",
+      "function": "extract_job_description",
+      "line": 136,
+      "cyclomatic": 7.0,
+      "coverage": 35.294117647058826,
+      "crap": 20.274781192753913
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "resolve_turbo_config_path_candidate",
+      "line": 332,
+      "cyclomatic": 4.0,
+      "coverage": 0.0,
+      "crap": 20.0
+    },
+    {
+      "file": "./src/runner.rs",
+      "function": "is_runner_available",
+      "line": 21,
+      "cyclomatic": 20.0,
+      "coverage": 100.0,
+      "crap": 20.0
+    },
+    {
+      "file": "./src/task_discovery/github_actions.rs",
+      "function": "discover_github_actions_tasks",
+      "line": 17,
+      "cyclomatic": 19.0,
+      "coverage": 88.88888888888889,
+      "crap": 19.49519890260631
+    },
+    {
+      "file": "./src/task_discovery/taskfile.rs",
+      "function": "collect_taskfile_tasks_recursive",
+      "line": 90,
+      "cyclomatic": 19.0,
+      "coverage": 94.73684210526315,
+      "crap": 19.05263157894737
+    },
+    {
+      "file": "./src/types.rs",
+      "function": "TaskRunner::short_name",
+      "line": 242,
+      "cyclomatic": 19.0,
+      "coverage": 95.23809523809523,
+      "crap": 19.038980671633734
+    },
+    {
+      "file": "./src/commands/init.rs",
+      "function": "execute",
+      "line": 100,
+      "cyclomatic": 18.0,
+      "coverage": 87.03703703703704,
+      "crap": 18.70576131687243
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "check_task_allowed",
+      "line": 144,
+      "cyclomatic": 12.0,
+      "coverage": 66.66666666666666,
+      "crap": 17.333333333333343
+    },
+    {
+      "file": "./src/mcp/errors.rs",
+      "function": "DelaError::runner_unavailable",
+      "line": 114,
+      "cyclomatic": 16.0,
+      "coverage": 83.33333333333334,
+      "crap": 17.185185185185183
+    },
+    {
+      "file": "./src/parsers/parse_travis_ci.rs",
+      "function": "parse_travis_string",
+      "line": 21,
+      "cyclomatic": 14.0,
+      "coverage": 75.0,
+      "crap": 17.0625
+    },
+    {
+      "file": "./src/commands/allow_command.rs",
+      "function": "execute",
+      "line": 8,
+      "cyclomatic": 17.0,
+      "coverage": 100.0,
+      "crap": 17.0
+    },
+    {
+      "file": "./src/commands/init.rs",
+      "function": "add_shell_integration",
+      "line": 50,
+      "cyclomatic": 16.0,
+      "coverage": 87.87878787878788,
+      "crap": 16.45590895177672
+    },
+    {
+      "file": "./src/commands/list.rs",
+      "function": "format_task_entry",
+      "line": 356,
+      "cyclomatic": 15.0,
+      "coverage": 83.33333333333334,
+      "crap": 16.041666666666664
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "resolve_effective_turbo_tasks",
+      "line": 172,
+      "cyclomatic": 15.0,
+      "coverage": 92.3076923076923,
+      "crap": 15.10241238051889
+    },
+    {
+      "file": "./src/task_discovery/support.rs",
+      "function": "set_definition",
+      "line": 12,
+      "cyclomatic": 14.0,
+      "coverage": 87.5,
+      "crap": 14.3828125
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "evaluate_task_against_allowlist",
+      "line": 75,
+      "cyclomatic": 14.0,
+      "coverage": 95.65217391304348,
+      "crap": 14.016109147694584
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_output",
+      "line": 1077,
+      "cyclomatic": 10.0,
+      "coverage": 68.18181818181817,
+      "crap": 13.221262208865516
+    },
+    {
+      "file": "./src/task_discovery/gradle.rs",
+      "function": "discover_gradle_tasks",
+      "line": 15,
+      "cyclomatic": 7.0,
+      "coverage": 50.0,
+      "crap": 13.125
+    },
+    {
+      "file": "./src/runners/runners_package_json.rs",
+      "function": "detect_package_manager",
+      "line": 6,
+      "cyclomatic": 13.0,
+      "coverage": 92.85714285714286,
+      "crap": 13.061588921282798
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "extract_include_directives_from_str",
+      "line": 106,
+      "cyclomatic": 13.0,
+      "coverage": 97.2972972972973,
+      "crap": 13.003336426272876
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "generate_config_at",
+      "line": 171,
+      "cyclomatic": 13.0,
+      "coverage": 100.0,
+      "crap": 13.0
+    },
+    {
+      "file": "./src/runners/runners_pyproject_toml.rs",
+      "function": "detect_package_manager",
+      "line": 21,
+      "cyclomatic": 11.0,
+      "coverage": 77.41935483870968,
+      "crap": 12.393138867443188
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "extract_tasks_regex",
+      "line": 229,
+      "cyclomatic": 12.0,
+      "coverage": 95.0,
+      "crap": 12.018
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "parse",
+      "line": 16,
+      "cyclomatic": 8.0,
+      "coverage": 61.111111111111114,
+      "crap": 11.764060356652948
+    },
+    {
+      "file": "./src/parsers/parse_turbo_json.rs",
+      "function": "json_type_name",
+      "line": 118,
+      "cyclomatic": 7.0,
+      "coverage": 55.55555555555556,
+      "crap": 11.301783264746227
+    },
+    {
+      "file": "./src/commands/run_command.rs",
+      "function": "execute",
+      "line": 8,
+      "cyclomatic": 11.0,
+      "coverage": 96.0,
+      "crap": 11.007744
+    },
+    {
+      "file": "./src/parsers/parse_gradle.rs",
+      "function": "extract_plugin_tasks",
+      "line": 174,
+      "cyclomatic": 11.0,
+      "coverage": 100.0,
+      "crap": 11.0
+    },
+    {
+      "file": "./src/task_discovery/make.rs",
+      "function": "collect_makefile_tasks_recursive",
+      "line": 91,
+      "cyclomatic": 11.0,
+      "coverage": 100.0,
+      "crap": 11.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "classify_output_log_level",
+      "line": 33,
+      "cyclomatic": 11.0,
+      "coverage": 100.0,
+      "crap": 11.0
+    },
+    {
+      "file": "./src/parsers/parse_cmake.rs",
+      "function": "find_closing_paren",
+      "line": 81,
+      "cyclomatic": 10.0,
+      "coverage": 79.3103448275862,
+      "crap": 10.885645167903563
+    },
+    {
+      "file": "./src/parsers/parse_gradle.rs",
+      "function": "extract_task_description",
+      "line": 132,
+      "cyclomatic": 10.0,
+      "coverage": 85.71428571428571,
+      "crap": 10.291545189504374
+    },
+    {
+      "file": "./src/prompt.rs",
+      "function": "prompt_for_task_fallback",
+      "line": 68,
+      "cyclomatic": 10.0,
+      "coverage": 90.32258064516128,
+      "crap": 10.090631398744588
+    },
+    {
+      "file": "./src/parsers/parse_gradle.rs",
+      "function": "extract_custom_tasks",
+      "line": 63,
+      "cyclomatic": 10.0,
+      "coverage": 100.0,
+      "crap": 10.0
+    },
+    {
+      "file": "./src/parsers/parse_justfile.rs",
+      "function": "parse",
+      "line": 7,
+      "cyclomatic": 9.0,
+      "coverage": 90.47619047619048,
+      "crap": 9.06997084548105
+    },
+    {
+      "file": "./src/commands/get_command.rs",
+      "function": "execute",
+      "line": 6,
+      "cyclomatic": 9.0,
+      "coverage": 91.42857142857143,
+      "crap": 9.051008746355684
+    },
+    {
+      "file": "./src/parsers/parse_pom_xml.rs",
+      "function": "add_plugin_tasks",
+      "line": 91,
+      "cyclomatic": 9.0,
+      "coverage": 95.83333333333334,
+      "crap": 9.005859375
+    },
+    {
+      "file": "./src/builtins.rs",
+      "function": "check_shell_builtin",
+      "line": 6,
+      "cyclomatic": 9.0,
+      "coverage": 100.0,
+      "crap": 9.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::append_initial_output",
+      "line": 213,
+      "cyclomatic": 6.0,
+      "coverage": 57.14285714285714,
+      "crap": 8.833819241982507
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "load_allowlist",
+      "line": 14,
+      "cyclomatic": 8.0,
+      "coverage": 94.11764705882352,
+      "crap": 8.013026663952779
+    },
+    {
+      "file": "./src/parsers/parse_justfile.rs",
+      "function": "validate_recipe_indentation",
+      "line": 72,
+      "cyclomatic": 8.0,
+      "coverage": 100.0,
+      "crap": 8.0
+    },
+    {
+      "file": "./src/parsers/parse_package_json.rs",
+      "function": "parse",
+      "line": 6,
+      "cyclomatic": 8.0,
+      "coverage": 100.0,
+      "crap": 8.0
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "looks_like_turbo_config_path",
+      "line": 322,
+      "cyclomatic": 8.0,
+      "coverage": 100.0,
+      "crap": 8.0
+    },
+    {
+      "file": "./src/task_discovery/disambiguation.rs",
+      "function": "process_task_disambiguation",
+      "line": 7,
+      "cyclomatic": 8.0,
+      "coverage": 100.0,
+      "crap": 8.0
+    },
+    {
+      "file": "./src/commands/init.rs",
+      "function": "get_shell_config_path",
+      "line": 32,
+      "cyclomatic": 8.0,
+      "coverage": 100.0,
+      "crap": 8.0
+    },
+    {
+      "file": "./src/commands/configure_shell.rs",
+      "function": "execute",
+      "line": 36,
+      "cyclomatic": 8.0,
+      "coverage": 100.0,
+      "crap": 8.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::template",
+      "line": 67,
+      "cyclomatic": 6.0,
+      "coverage": 62.5,
+      "crap": 7.8984375
+    },
+    {
+      "file": "./src/task_discovery/disambiguation.rs",
+      "function": "generate_prefix_from_short_name",
+      "line": 56,
+      "cyclomatic": 7.0,
+      "coverage": 74.07407407407408,
+      "crap": 7.853884062388863
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_stop",
+      "line": 1172,
+      "cyclomatic": 7.0,
+      "coverage": 76.74418604651163,
+      "crap": 7.616297936030789
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::update_job_state",
+      "line": 384,
+      "cyclomatic": 5.0,
+      "coverage": 53.333333333333336,
+      "crap": 7.540740740740741
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::push_line",
+      "line": 63,
+      "cyclomatic": 7.0,
+      "coverage": 80.0,
+      "crap": 7.3919999999999995
+    },
+    {
+      "file": "./src/parsers/parse_github_actions.rs",
+      "function": "parse_workflow_string",
+      "line": 21,
+      "cyclomatic": 7.0,
+      "coverage": 82.6086956521739,
+      "crap": 7.257746363113339
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "collect_descendant_turbo_config_paths_recursive",
+      "line": 284,
+      "cyclomatic": 7.0,
+      "coverage": 88.0,
+      "crap": 7.084672
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "extract_tasks",
+      "line": 46,
+      "cyclomatic": 7.0,
+      "coverage": 94.87179487179486,
+      "crap": 7.0066083379692845
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "collapse_line_continuations",
+      "line": 157,
+      "cyclomatic": 7.0,
+      "coverage": 96.7741935483871,
+      "crap": 7.001644792051291
+    },
+    {
+      "file": "./src/parsers/parse_turbo_json.rs",
+      "function": "load_config",
+      "line": 35,
+      "cyclomatic": 7.0,
+      "coverage": 100.0,
+      "crap": 7.0
+    },
+    {
+      "file": "./src/commands/configure_shell.rs",
+      "function": "Shell::from_path",
+      "line": 19,
+      "cyclomatic": 7.0,
+      "coverage": 100.0,
+      "crap": 7.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::name",
+      "line": 46,
+      "cyclomatic": 6.0,
+      "coverage": 75.0,
+      "crap": 6.5625
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "save_allowlist",
+      "line": 40,
+      "cyclomatic": 6.0,
+      "coverage": 91.66666666666666,
+      "crap": 6.020833333333333
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::record_completed_job",
+      "line": 324,
+      "cyclomatic": 6.0,
+      "coverage": 93.54838709677419,
+      "crap": 6.009667349199423
+    },
+    {
+      "file": "./src/task_discovery/shell_scripts.rs",
+      "function": "discover_shell_script_tasks",
+      "line": 15,
+      "cyclomatic": 6.0,
+      "coverage": 96.96969696969697,
+      "crap": 6.001001753067869
+    },
+    {
+      "file": "./src/parsers/parse_docker_compose.rs",
+      "function": "parse",
+      "line": 35,
+      "cyclomatic": 6.0,
+      "coverage": 97.77777777777777,
+      "crap": 6.000395061728395
+    },
+    {
+      "file": "./src/parsers/parse_taskfile.rs",
+      "function": "extract_include_directives",
+      "line": 152,
+      "cyclomatic": 6.0,
+      "coverage": 100.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/parsers/parse_cmake.rs",
+      "function": "parse_cmake_string",
+      "line": 21,
+      "cyclomatic": 6.0,
+      "coverage": 100.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::send_task_output",
+      "line": 280,
+      "cyclomatic": 2.0,
+      "coverage": 0.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::serve_stdio",
+      "line": 338,
+      "cyclomatic": 2.0,
+      "coverage": 0.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::initialize",
+      "line": 1251,
+      "cyclomatic": 2.0,
+      "coverage": 0.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/mcp/errors.rs",
+      "function": "DelaError::to_error_data",
+      "line": 65,
+      "cyclomatic": 6.0,
+      "coverage": 100.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/repo_root.rs",
+      "function": "find_ancestor",
+      "line": 3,
+      "cyclomatic": 6.0,
+      "coverage": 100.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/runners/runners_pyproject_toml.rs",
+      "function": "parse",
+      "line": 11,
+      "cyclomatic": 2.0,
+      "coverage": 0.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::config_path",
+      "line": 56,
+      "cyclomatic": 6.0,
+      "coverage": 100.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "merge_dela_into_json",
+      "line": 110,
+      "cyclomatic": 6.0,
+      "coverage": 100.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/task_discovery/maven.rs",
+      "function": "discover_maven_tasks",
+      "line": 15,
+      "cyclomatic": 4.0,
+      "coverage": 55.55555555555556,
+      "crap": 5.404663923182442
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::get_stats",
+      "line": 685,
+      "cyclomatic": 5.0,
+      "coverage": 88.23529411764706,
+      "crap": 5.0407083248524325
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "active_dela_config_dir",
+      "line": 39,
+      "cyclomatic": 5.0,
+      "coverage": 90.9090909090909,
+      "crap": 5.018782870022539
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "collect_turbo_ancestor_config_paths",
+      "line": 259,
+      "cyclomatic": 5.0,
+      "coverage": 92.3076923076923,
+      "crap": 5.011379153390988
+    },
+    {
+      "file": "./src/parsers/parse_pom_xml.rs",
+      "function": "parse",
+      "line": 9,
+      "cyclomatic": 5.0,
+      "coverage": 100.0,
+      "crap": 5.0
+    },
+    {
+      "file": "./src/parsers/parse_taskfile.rs",
+      "function": "resolve_taskfile_include_path",
+      "line": 92,
+      "cyclomatic": 5.0,
+      "coverage": 100.0,
+      "crap": 5.0
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "active_allowlist_path",
+      "line": 57,
+      "cyclomatic": 5.0,
+      "coverage": 100.0,
+      "crap": 5.0
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "is_task_allowed",
+      "line": 132,
+      "cyclomatic": 5.0,
+      "coverage": 100.0,
+      "crap": 5.0
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "build_turbo_package_config_index",
+      "line": 348,
+      "cyclomatic": 4.0,
+      "coverage": 75.0,
+      "crap": 4.25
+    },
+    {
+      "file": "./src/task_discovery/travis_ci.rs",
+      "function": "discover_travis_ci_tasks",
+      "line": 17,
+      "cyclomatic": 4.0,
+      "coverage": 75.0,
+      "crap": 4.25
+    },
+    {
+      "file": "./src/task_discovery/docker_compose.rs",
+      "function": "discover_docker_compose_tasks",
+      "line": 15,
+      "cyclomatic": 4.0,
+      "coverage": 75.75757575757575,
+      "crap": 4.22795447588836
+    },
+    {
+      "file": "./src/task_discovery/justfile.rs",
+      "function": "discover_justfile_tasks",
+      "line": 15,
+      "cyclomatic": 4.0,
+      "coverage": 76.47058823529412,
+      "crap": 4.208426623244454
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "merge_dela_into_toml",
+      "line": 140,
+      "cyclomatic": 4.0,
+      "coverage": 82.6086956521739,
+      "crap": 4.084162077751294
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::servers_key",
+      "line": 85,
+      "cyclomatic": 4.0,
+      "coverage": 83.33333333333334,
+      "crap": 4.0740740740740735
+    },
+    {
+      "file": "./src/task_discovery/cmake.rs",
+      "function": "discover_cmake_tasks",
+      "line": 17,
+      "cyclomatic": 4.0,
+      "coverage": 85.0,
+      "crap": 4.054
+    },
+    {
+      "file": "./src/commands/init.rs",
+      "function": "get_current_shell",
+      "line": 11,
+      "cyclomatic": 4.0,
+      "coverage": 86.66666666666667,
+      "crap": 4.037925925925926
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "discover_turbo_tasks",
+      "line": 33,
+      "cyclomatic": 4.0,
+      "coverage": 90.0,
+      "crap": 4.016
+    },
+    {
+      "file": "./src/parsers/parse_docker_compose.rs",
+      "function": "find_docker_compose_files",
+      "line": 95,
+      "cyclomatic": 4.0,
+      "coverage": 93.54838709677419,
+      "crap": 4.004296599644188
+    },
+    {
+      "file": "./src/parsers/parse_taskfile.rs",
+      "function": "parse",
+      "line": 107,
+      "cyclomatic": 4.0,
+      "coverage": 93.75,
+      "crap": 4.00390625
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "OutputNotificationBatch::take_notification_data",
+      "line": 108,
+      "cyclomatic": 4.0,
+      "coverage": 95.65217391304348,
+      "crap": 4.001315032464864
+    },
+    {
+      "file": "./src/parsers/parse_pom_xml.rs",
+      "function": "add_profile_tasks",
+      "line": 56,
+      "cyclomatic": 4.0,
+      "coverage": 100.0,
+      "crap": 4.0
+    },
+    {
+      "file": "./src/parsers/parse_gradle.rs",
+      "function": "parse",
+      "line": 9,
+      "cyclomatic": 4.0,
+      "coverage": 100.0,
+      "crap": 4.0
+    },
+    {
+      "file": "./src/parsers/parse_justfile.rs",
+      "function": "get_indentation_type",
+      "line": 125,
+      "cyclomatic": 4.0,
+      "coverage": 100.0,
+      "crap": 4.0
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "contains_dynamic_make_syntax",
+      "line": 224,
+      "cyclomatic": 4.0,
+      "coverage": 100.0,
+      "crap": 4.0
+    },
+    {
+      "file": "./src/task_discovery/npm.rs",
+      "function": "discover_npm_tasks",
+      "line": 15,
+      "cyclomatic": 4.0,
+      "coverage": 100.0,
+      "crap": 4.0
+    },
+    {
+      "file": "./src/task_discovery/python.rs",
+      "function": "discover_python_tasks",
+      "line": 15,
+      "cyclomatic": 4.0,
+      "coverage": 100.0,
+      "crap": 4.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::resolve_wait_for_exit_seconds",
+      "line": 260,
+      "cyclomatic": 4.0,
+      "coverage": 100.0,
+      "crap": 4.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::send_log",
+      "line": 201,
+      "cyclomatic": 2.0,
+      "coverage": 36.36363636363637,
+      "crap": 3.0308039068369643
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::start_job",
+      "line": 283,
+      "cyclomatic": 3.0,
+      "coverage": 86.20689655172413,
+      "crap": 3.0236172044774285
+    },
+    {
+      "file": "./src/commands/list.rs",
+      "function": "format_task_entry_with_source",
+      "line": 445,
+      "cyclomatic": 3.0,
+      "coverage": 87.5,
+      "crap": 3.017578125
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "resolve_turbo_extends_entry",
+      "line": 238,
+      "cyclomatic": 3.0,
+      "coverage": 88.88888888888889,
+      "crap": 3.0123456790123457
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::remove_job",
+      "line": 617,
+      "cyclomatic": 3.0,
+      "coverage": 88.88888888888889,
+      "crap": 3.0123456790123457
+    },
+    {
+      "file": "./src/task_discovery/make.rs",
+      "function": "find_makefile_path",
+      "line": 74,
+      "cyclomatic": 3.0,
+      "coverage": 91.66666666666666,
+      "crap": 3.0052083333333335
+    },
+    {
+      "file": "./src/parsers/parse_taskfile.rs",
+      "function": "find_taskfile_in_dir",
+      "line": 81,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/parsers/parse_taskfile.rs",
+      "function": "load_taskfile",
+      "line": 189,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/parsers/parse_taskfile.rs",
+      "function": "should_skip_non_local_include",
+      "line": 202,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/parsers/parse_travis_ci.rs",
+      "function": "parse",
+      "line": 12,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/parsers/parse_github_actions.rs",
+      "function": "parse",
+      "line": 12,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/parsers/parse_turbo_json.rs",
+      "function": "TurboTaskConfig::is_effective_task_definition",
+      "line": 15,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/parsers/parse_cmake.rs",
+      "function": "parse",
+      "line": 12,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "read_package_name",
+      "line": 371,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/task_discovery/taskfile.rs",
+      "function": "discover_taskfile_tasks",
+      "line": 17,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/task_discovery/make.rs",
+      "function": "discover_makefile_tasks",
+      "line": 20,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::get_output_lines",
+      "line": 192,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::get_discovered_tasks",
+      "line": 317,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/runner.rs",
+      "function": "split_command_words",
+      "line": 10,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/runner.rs",
+      "function": "is_runner_available_for_mcp",
+      "line": 50,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "check_task_allowed_with_scope",
+      "line": 189,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/commands/list.rs",
+      "function": "task_source_label",
+      "line": 458,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::dela_marker",
+      "line": 77,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::dela_json_entry",
+      "line": 94,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "RealEnvironment::check_executable",
+      "line": 21,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::flush_output_notification_batch",
+      "line": 233,
+      "cyclomatic": 2.0,
+      "coverage": 58.82352941176471,
+      "crap": 2.2792591084876856
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::can_start_job",
+      "line": 269,
+      "cyclomatic": 2.0,
+      "coverage": 66.66666666666666,
+      "crap": 2.1481481481481484
+    },
+    {
+      "file": "./src/commands/list.rs",
+      "function": "format_definition_path_for_display",
+      "line": 472,
+      "cyclomatic": 2.0,
+      "coverage": 80.0,
+      "crap": 2.032
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::add_job_output",
+      "line": 404,
+      "cyclomatic": 2.0,
+      "coverage": 85.71428571428571,
+      "crap": 2.011661807580175
+    },
+    {
+      "file": "./src/commands/list.rs",
+      "function": "format_runner_path_for_display",
+      "line": 480,
+      "cyclomatic": 2.0,
+      "coverage": 85.71428571428571,
+      "crap": 2.011661807580175
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "resolve_nested_definition_path",
+      "line": 81,
+      "cyclomatic": 2.0,
+      "coverage": 90.0,
+      "crap": 2.004
+    },
+    {
+      "file": "./src/parsers/parse_pom_xml.rs",
+      "function": "add_default_maven_goals",
+      "line": 34,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/parsers/parse_gradle.rs",
+      "function": "add_common_tasks",
+      "line": 29,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/parsers/parse_justfile.rs",
+      "function": "is_indented_line",
+      "line": 120,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "extract_include_directives",
+      "line": 101,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/parsers/parse_makefile.rs",
+      "function": "split_include_fallback",
+      "line": 220,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/parsers/parse_turbo_json.rs",
+      "function": "parse",
+      "line": 62,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/types.rs",
+      "function": "deserialize_path",
+      "line": 315,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/task_discovery/disambiguation.rs",
+      "function": "get_disambiguated_task_names",
+      "line": 98,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/task_discovery/disambiguation.rs",
+      "function": "format_ambiguous_task_error",
+      "line": 121,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/task_discovery/support.rs",
+      "function": "apply_shadowing",
+      "line": 6,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/task_discovery/taskfile.rs",
+      "function": "prefix_taskfile_task_name",
+      "line": 193,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/builtins.rs",
+      "function": "check_zsh_builtin",
+      "line": 22,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/builtins.rs",
+      "function": "check_bash_builtin",
+      "line": 90,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/builtins.rs",
+      "function": "check_fish_builtin",
+      "line": 163,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/builtins.rs",
+      "function": "check_pwsh_builtin",
+      "line": 236,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "preferred_config_dir_path",
+      "line": 24,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "legacy_dela_config_dir",
+      "line": 29,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "legacy_allowlist_path",
+      "line": 34,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "preferred_allowlist_path",
+      "line": 53,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "ComposedDefinitionSource::apply_to_task",
+      "line": 42,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "RecursiveDiscoveryState::mark_visited",
+      "line": 70,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::get_last_lines",
+      "line": 88,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::is_empty",
+      "line": 110,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::add_output",
+      "line": 183,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::idle_time",
+      "line": 213,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "OutputNotificationBatch::add_line",
+      "line": 86,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "OutputNotificationBatch::should_flush",
+      "line": 98,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::list_tasks",
+      "line": 356,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::list_tools",
+      "line": 1343,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::set_level",
+      "line": 1670,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/mod.rs",
+      "function": "run_stdio_server",
+      "line": 12,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/allowlist.rs",
+      "function": "McpAllowlistEvaluator::new",
+      "line": 18,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "task_name_normal",
+      "line": 4,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "task_name_ambiguous",
+      "line": 8,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "task_name_shadowed",
+      "line": 12,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "footnote_symbol",
+      "line": 17,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "footnote_description",
+      "line": 21,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "task_runner_available",
+      "line": 26,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "task_runner_unavailable",
+      "line": 30,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "task_definition_file",
+      "line": 35,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "section_count",
+      "line": 40,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "task_description",
+      "line": 45,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "task_description_dash",
+      "line": 49,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "status_success",
+      "line": 54,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "status_warning",
+      "line": 58,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "status_error",
+      "line": 62,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "status_not_found",
+      "line": 66,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "error_header",
+      "line": 71,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "error_bullet",
+      "line": 75,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "error_message",
+      "line": 79,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "info_message",
+      "line": 84,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/colors.rs",
+      "function": "info_header",
+      "line": 88,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "allowlist_path",
+      "line": 8,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "path_matches",
+      "line": 57,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "allowlist_entry_for_task",
+      "line": 115,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/prompt.rs",
+      "function": "ui",
+      "line": 169,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/task_discovery.rs",
+      "function": "discover_tasks",
+      "line": 67,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/commands/run.rs",
+      "function": "execute",
+      "line": 3,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "generate_config",
+      "line": 237,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "TestEnvironment::check_executable",
+      "line": 72,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/task_shadowing.rs",
+      "function": "unmock_executable",
+      "line": 18,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/task_shadowing.rs",
+      "function": "disable_mock",
+      "line": 28,
+      "cyclomatic": 1.0,
+      "coverage": 0.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/task_shadowing.rs",
+      "function": "check_shadowing",
+      "line": 39,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/parsers/parse_taskfile.rs",
+      "function": "looks_like_taskfile_file",
+      "line": 196,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/parsers/parse_turbo_json.rs",
+      "function": "TurboConfig::task_names",
+      "line": 27,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/parsers/parse_turbo_json.rs",
+      "function": "parse_task_config",
+      "line": 81,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/parsers/parse_turbo_json.rs",
+      "function": "parse_task_map",
+      "line": 100,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/types.rs",
+      "function": "Task::definition_path",
+      "line": 187,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/types.rs",
+      "function": "Task::allowlist_path",
+      "line": 192,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/types.rs",
+      "function": "serialize_path",
+      "line": 308,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/github_actions.rs",
+      "function": "GithubActionsDiscovery::discover",
+      "line": 12,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/npm.rs",
+      "function": "NpmDiscovery::discover",
+      "line": 10,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "TurboDiscovery::discover",
+      "line": 28,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "collect_descendant_turbo_config_paths",
+      "line": 277,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/turbo.rs",
+      "function": "should_skip_turbo_config_scan",
+      "line": 318,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/cmake.rs",
+      "function": "CmakeDiscovery::discover",
+      "line": 12,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/registry.rs",
+      "function": "registered_discoveries",
+      "line": 23,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/disambiguation.rs",
+      "function": "generate_runner_prefix",
+      "line": 51,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/disambiguation.rs",
+      "function": "is_task_ambiguous",
+      "line": 90,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/disambiguation.rs",
+      "function": "get_matching_tasks",
+      "line": 107,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/support.rs",
+      "function": "handle_discovery_error",
+      "line": 36,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/support.rs",
+      "function": "handle_discovery_success",
+      "line": 57,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/taskfile.rs",
+      "function": "TaskfileDiscovery::discover",
+      "line": 12,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/docker_compose.rs",
+      "function": "DockerComposeDiscovery::discover",
+      "line": 10,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/travis_ci.rs",
+      "function": "TravisCiDiscovery::discover",
+      "line": 12,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/justfile.rs",
+      "function": "JustfileDiscovery::discover",
+      "line": 10,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/shell_scripts.rs",
+      "function": "ShellScriptDiscovery::discover",
+      "line": 10,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/maven.rs",
+      "function": "MavenDiscovery::discover",
+      "line": 10,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/make.rs",
+      "function": "MakefileDiscovery::discover",
+      "line": 15,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/python.rs",
+      "function": "PythonDiscovery::discover",
+      "line": 10,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery/gradle.rs",
+      "function": "GradleDiscovery::discover",
+      "line": 10,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "preferred_config_dir_path_for",
+      "line": 11,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "preferred_allowlist_path_for",
+      "line": 16,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/config.rs",
+      "function": "legacy_allowlist_path_for",
+      "line": 20,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "ComposedDefinitionSource::direct",
+      "line": 16,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "ComposedDefinitionSource::composed",
+      "line": 25,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "ComposedDefinitionSource::definition_path",
+      "line": 32,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "ComposedDefinitionSource::resolve_child",
+      "line": 37,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/composed_paths.rs",
+      "function": "RecursiveDiscoveryState::new",
+      "line": 66,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::new",
+      "line": 53,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::get_all_lines",
+      "line": 99,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::len",
+      "line": 104,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::is_full",
+      "line": 115,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::capacity",
+      "line": 120,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::total_bytes",
+      "line": 125,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::new",
+      "line": 144,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::touch",
+      "line": 162,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::mark_exited",
+      "line": 167,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::mark_failed",
+      "line": 175,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::is_running",
+      "line": 200,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::age",
+      "line": 206,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManagerConfig::default",
+      "line": 231,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::new",
+      "line": 254,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::with_config",
+      "line": 259,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::get_job",
+      "line": 363,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::get_all_jobs",
+      "line": 369,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::get_jobs_by_name",
+      "line": 375,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "OutputNotificationBatch::new",
+      "line": 73,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "OutputNotificationBatch::is_empty",
+      "line": 82,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "OutputNotificationBatch::flush_due_at",
+      "line": 103,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::new",
+      "line": 161,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::new_inner",
+      "line": 169,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::new_with_allowlist",
+      "line": 187,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::new_with_allowlist_and_cache_ttl",
+      "line": 192,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::output_flush_timer_deadline",
+      "line": 253,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::send_task_event",
+      "line": 298,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::root",
+      "line": 313,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::status",
+      "line": 383,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_status",
+      "line": 1034,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::get_info",
+      "line": 1232,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::set_level_impl",
+      "line": 1682,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::set_level_impl",
+      "line": 1688,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/allowlist.rs",
+      "function": "McpAllowlistEvaluator::is_task_allowed",
+      "line": 36,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/allowlist.rs",
+      "function": "McpAllowlistEvaluator::entry_count",
+      "line": 45,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/allowlist.rs",
+      "function": "McpAllowlistEvaluator::is_empty",
+      "line": 51,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/errors.rs",
+      "function": "ErrorCode::from",
+      "line": 27,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/errors.rs",
+      "function": "DelaError::not_allowlisted",
+      "line": 106,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/errors.rs",
+      "function": "DelaError::task_not_found",
+      "line": 161,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/errors.rs",
+      "function": "DelaError::internal_error",
+      "line": 169,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/errors.rs",
+      "function": "DelaError::mcp_not_ready",
+      "line": 174,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/errors.rs",
+      "function": "ErrorData::from",
+      "line": 186,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/dto.rs",
+      "function": "TaskDto::from_task",
+      "line": 47,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/dto.rs",
+      "function": "TaskDto::from_task_enriched",
+      "line": 66,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/repo_root.rs",
+      "function": "find_git_repo_root",
+      "line": 24,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery.rs",
+      "function": "DiscoveredTasks::new",
+      "line": 52,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_discovery.rs",
+      "function": "DiscoveredTasks::add_task",
+      "line": 57,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "RealEnvironment::get_shell",
+      "line": 17,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "RealEnvironment::get_home",
+      "line": 31,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "TestEnvironment::new",
+      "line": 47,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "TestEnvironment::with_shell",
+      "line": 51,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "TestEnvironment::with_executable",
+      "line": 56,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "TestEnvironment::with_home",
+      "line": 61,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "TestEnvironment::get_shell",
+      "line": 68,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "TestEnvironment::get_home",
+      "line": 80,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "set_test_environment",
+      "line": 91,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "reset_to_real_environment",
+      "line": 97,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "get_current_home",
+      "line": 102,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/environment.rs",
+      "function": "get_current_shell",
+      "line": 107,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_shadowing.rs",
+      "function": "mock_executable",
+      "line": 13,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_shadowing.rs",
+      "function": "enable_mock",
+      "line": 23,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_shadowing.rs",
+      "function": "reset_mock",
+      "line": 33,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/task_shadowing.rs",
+      "function": "check_path_executable",
+      "line": 50,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    }
+  ]
+}

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -345,21 +345,16 @@ Advanced MCP features for better editor integration and real-time feedback.
 
 ## Technical Debt & Code Cleanup (Phase 11)
 
-**Issue 1: `DiscoveredTaskDefinitions` OCP Violation & Data Drift**
 - [ ] **[DTKT-202]** Refactor `DiscoveredTaskDefinitions` to use a grouped map collection (`BTreeMap<TaskDefinitionType, Vec<TaskDefinitionFile>>`) instead of hardcoded fields. This preserves predictable output ordering while robustly capturing multiple definitions per parser (e.g., included Makefiles or workspace-local `turbo.json` configs).
 - [ ] **[DTKT-203]** Migrate all dependent discovery and output layers to iterate dynamically over the new collection, allowing new parsers (e.g., TravisCi, CMake, Justfile) to correctly store their statuses.
 
-**Issue 2: Copy-Paste Formatting Boilerplate in `list.rs`**
 - [ ] **[DTKT-204]** Consolidate the 100+ lines of duplicated `TaskFileStatus` match formatting blocks in `src/commands/list.rs` into a single loop mapping over the refactored `DiscoveredTaskDefinitions`.
 
-**Issue 3: `test_println!` Macro Abuse (Untestable I/O)**
 - [ ] **[DTKT-205]** Deprecate the hacky `test_println!` macro and abstract CLI formatting: Inject a `&mut dyn std::io::Write` interface (or an abstract output buffer) across commands.
 - [ ] **[DTKT-206]** Update tests in `list.rs` to pass a mock buffer and write explicit assertions against the output strings instead of discarding stdout.
 
-**Issue 4: Monolithic God Files**
 - [ ] **[DTKT-207]** Abstract the ~350-line `task_start` routing function and other large handlers inside `mcp/server.rs` into discrete `handlers/` modules. Move their respective inline tests to the bottom of these new handler files to keep them bundled with the logic.
 
-**Issue 5: `.unwrap()` Remediation & Testing Robustness**
 - [ ] **[DTKT-208]** Enable `#![warn(clippy::unwrap_used)]` or set up a linter block for `.unwrap()` across the project.
 - [ ] **[DTKT-209]** Audit and replace `.unwrap()` usage in production code (`src/`), ensuring all paths bubble up robust `Result` types.
 - [ ] **[DTKT-210]** Refactor the most brittle test blocks to return `anyhow::Result<()>` and use idiomatic `assert!(matches!(...))` rather than panicking on `None` or `Err`.

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -343,6 +343,27 @@ Advanced MCP features for better editor integration and real-time feedback.
 
 **Deliverable (10C):** Enhanced MCP experience with real-time streaming, resource access, and editor-specific integrations.
 
+## Technical Debt & Code Cleanup (Phase 11)
+
+**Issue 1: `DiscoveredTaskDefinitions` OCP Violation & Data Drift**
+- [ ] **[DTKT-202]** Refactor `DiscoveredTaskDefinitions` to use a grouped map collection (`BTreeMap<TaskDefinitionType, Vec<TaskDefinitionFile>>`) instead of hardcoded fields. This preserves predictable output ordering while robustly capturing multiple definitions per parser (e.g., included Makefiles or workspace-local `turbo.json` configs).
+- [ ] **[DTKT-203]** Migrate all dependent discovery and output layers to iterate dynamically over the new collection, allowing new parsers (e.g., TravisCi, CMake, Justfile) to correctly store their statuses.
+
+**Issue 2: Copy-Paste Formatting Boilerplate in `list.rs`**
+- [ ] **[DTKT-204]** Consolidate the 100+ lines of duplicated `TaskFileStatus` match formatting blocks in `src/commands/list.rs` into a single loop mapping over the refactored `DiscoveredTaskDefinitions`.
+
+**Issue 3: `test_println!` Macro Abuse (Untestable I/O)**
+- [ ] **[DTKT-205]** Deprecate the hacky `test_println!` macro and abstract CLI formatting: Inject a `&mut dyn std::io::Write` interface (or an abstract output buffer) across commands.
+- [ ] **[DTKT-206]** Update tests in `list.rs` to pass a mock buffer and write explicit assertions against the output strings instead of discarding stdout.
+
+**Issue 4: Monolithic God Files**
+- [ ] **[DTKT-207]** Abstract the ~350-line `task_start` routing function and other large handlers inside `mcp/server.rs` into discrete `handlers/` modules. Move their respective inline tests to the bottom of these new handler files to keep them bundled with the logic.
+
+**Issue 5: `.unwrap()` Remediation & Testing Robustness**
+- [ ] **[DTKT-208]** Enable `#![warn(clippy::unwrap_used)]` or set up a linter block for `.unwrap()` across the project.
+- [ ] **[DTKT-209]** Audit and replace `.unwrap()` usage in production code (`src/`), ensuring all paths bubble up robust `Result` types.
+- [ ] **[DTKT-210]** Refactor the most brittle test blocks to return `anyhow::Result<()>` and use idiomatic `assert!(matches!(...))` rather than panicking on `None` or `Err`.
+
 ## Icebox and Future Enhancements (Post-Launch)
 
 - [ ] **Desirable**

--- a/dev_docs/testing.md
+++ b/dev_docs/testing.md
@@ -56,3 +56,6 @@ Each shell type (bash, fish, zsh, pwsh) has its own Dockerfile in the `tests/doc
    - Proper file permissions and ownership
 
 The `docker_noinit` container provides a clean environment for testing dela without any shell initialization, ensuring dela works correctly even without shell-specific configurations.
+
+## Change Risk Anti-Patterns (CRAP)
+There is a crap metric baseline in `cargo_crap_baseline.json`. Run `make crap_check` to make sure that you are not increasing the untested complexity of the code. If that crap increase is too high, refactor the code, otherwise update the baseline with `make crap_update`.

--- a/dev_docs/testing.md
+++ b/dev_docs/testing.md
@@ -58,4 +58,5 @@ Each shell type (bash, fish, zsh, pwsh) has its own Dockerfile in the `tests/doc
 The `docker_noinit` container provides a clean environment for testing dela without any shell initialization, ensuring dela works correctly even without shell-specific configurations.
 
 ## Change Risk Anti-Patterns (CRAP)
+
 There is a crap metric baseline in `cargo_crap_baseline.json`. Run `make crap_check` to make sure that you are not increasing the untested complexity of the code. If that crap increase is too high, refactor the code, otherwise update the baseline with `make crap_update`.

--- a/make/crap.mk
+++ b/make/crap.mk
@@ -1,0 +1,21 @@
+.PHONY: crap_check crap_update crap_run _crap_deps
+
+_crap_deps:
+	@echo "Checking dependencies (cargo-llvm-cov and cargo-crap)..."
+	@cargo llvm-cov --version 2>/dev/null | grep -q "0.8.7" || cargo install cargo-llvm-cov --version 0.8.7 --force --locked
+	@cargo crap --version 2>/dev/null | grep -q "0.2.0" || cargo install cargo-crap --version 0.2.0 --force --locked
+
+crap_run: _crap_deps
+	@echo "Running CRAP analysis..."
+	cargo llvm-cov --lcov --output-path lcov.info
+	cargo crap --lcov lcov.info --top 20
+
+crap_check: _crap_deps
+	@echo "Checking CRAP against baseline..."
+	cargo llvm-cov --lcov --output-path lcov.info
+	cargo crap --lcov lcov.info --baseline cargo_crap_baseline.json --fail-regression
+
+crap_update: _crap_deps
+	@echo "Updating CRAP baseline..."
+	cargo llvm-cov --lcov --output-path lcov.info
+	cargo crap --lcov lcov.info --format json --output cargo_crap_baseline.json

--- a/make/crap.mk
+++ b/make/crap.mk
@@ -13,7 +13,7 @@ crap_run: _crap_deps
 crap_check: _crap_deps
 	@echo "Checking CRAP against baseline..."
 	cargo llvm-cov --lcov --output-path lcov.info
-	cargo crap --lcov lcov.info --baseline cargo_crap_baseline.json --fail-regression
+	cargo crap --lcov lcov.info --baseline cargo_crap_baseline.json --fail-regression --format pr-comment
 
 crap_update: _crap_deps
 	@echo "Updating CRAP baseline..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added build targets to run CRAP/code-risk analysis, generate coverage output, and update/check a CRAP baseline.
  * Introduced a baseline report for code-risk metrics.
  * Updated ignore rules to exclude generated coverage output.

* **Documentation**
  * Added Phase 11 to the project roadmap for technical debt and cleanup tracking, and documented CRAP usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aleyan/dela/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->