### PR TITLE
Add `dela deny`

### DIFF
--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -181,7 +181,7 @@
     {
       "file": "./src/allowlist.rs",
       "function": "check_task_allowed",
-      "line": 144,
+      "line": 148,
       "cyclomatic": 12.0,
       "coverage": 66.66666666666666,
       "crap": 17.333333333333343
@@ -201,6 +201,14 @@
       "cyclomatic": 14.0,
       "coverage": 75.0,
       "crap": 17.0625
+    },
+    {
+      "file": "./src/allowlist.rs",
+      "function": "evaluate_task_against_allowlist",
+      "line": 75,
+      "cyclomatic": 17.0,
+      "coverage": 100.0,
+      "crap": 17.0
     },
     {
       "file": "./src/commands/allow_command.rs",
@@ -233,14 +241,6 @@
       "cyclomatic": 15.0,
       "coverage": 92.3076923076923,
       "crap": 15.10241238051889
-    },
-    {
-      "file": "./src/allowlist.rs",
-      "function": "evaluate_task_against_allowlist",
-      "line": 75,
-      "cyclomatic": 14.0,
-      "coverage": 100.0,
-      "crap": 14.0
     },
     {
       "file": "./src/mcp/server.rs",
@@ -765,7 +765,7 @@
     {
       "file": "./src/allowlist.rs",
       "function": "is_task_allowed",
-      "line": 132,
+      "line": 136,
       "cyclomatic": 5.0,
       "coverage": 100.0,
       "crap": 5.0
@@ -1076,8 +1076,16 @@
     },
     {
       "file": "./src/allowlist.rs",
+      "function": "allowlist_entry_for_task",
+      "line": 119,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/allowlist.rs",
       "function": "check_task_allowed_with_scope",
-      "line": 189,
+      "line": 193,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0
@@ -1598,14 +1606,6 @@
       "file": "./src/allowlist.rs",
       "function": "path_matches",
       "line": 57,
-      "cyclomatic": 2.0,
-      "coverage": 100.0,
-      "crap": 2.0
-    },
-    {
-      "file": "./src/allowlist.rs",
-      "function": "allowlist_entry_for_task",
-      "line": 115,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -7,8 +7,8 @@
       "function": "JobManager::stop_job_graceful",
       "line": 439,
       "cyclomatic": 29.0,
-      "coverage": 24.691358024691358,
-      "crap": 388.19513360843445
+      "coverage": 34.5679012345679,
+      "crap": 264.5963446553804
     },
     {
       "file": "./src/mcp/server.rs",
@@ -45,10 +45,10 @@
     {
       "file": "./src/main.rs",
       "function": "run_command",
-      "line": 172,
-      "cyclomatic": 10.0,
-      "coverage": 21.428571428571427,
-      "crap": 58.505830903790084
+      "line": 182,
+      "cyclomatic": 11.0,
+      "coverage": 20.689655172413794,
+      "crap": 71.36356554184265
     },
     {
       "file": "./src/prompt.rs",
@@ -293,7 +293,7 @@
     {
       "file": "./src/main.rs",
       "function": "main",
-      "line": 209,
+      "line": 220,
       "cyclomatic": 3.0,
       "coverage": 0.0,
       "crap": 12.0
@@ -676,6 +676,14 @@
     },
     {
       "file": "./src/commands/allow.rs",
+      "function": "execute",
+      "line": 7,
+      "cyclomatic": 6.0,
+      "coverage": 100.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/commands/deny.rs",
       "function": "execute",
       "line": 7,
       "cyclomatic": 6.0,

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -7,8 +7,8 @@
       "function": "JobManager::stop_job_graceful",
       "line": 439,
       "cyclomatic": 29.0,
-      "coverage": 34.5679012345679,
-      "crap": 264.5963446553804
+      "coverage": 24.691358024691358,
+      "crap": 388.19513360843445
     },
     {
       "file": "./src/mcp/server.rs",
@@ -239,8 +239,8 @@
       "function": "evaluate_task_against_allowlist",
       "line": 75,
       "cyclomatic": 14.0,
-      "coverage": 95.65217391304348,
-      "crap": 14.016109147694584
+      "coverage": 100.0,
+      "crap": 14.0
     },
     {
       "file": "./src/mcp/server.rs",

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -131,7 +131,7 @@ This plan outlines the major development phases and tasks for building `dela`, a
   - [x] [DTKT-32] Persist decisions in the allowlist.
   - [ ] [DTKT-33] Have `dela run` take an optional `--allow` flag to allow a task without prompting.
   - [x] [DTKT-109] Implement `dela allow` command to add allowlist entries.
-  - [ ] [DTKT-110] Implement `dela deny` command to add denylist entries.
+  - [x] [DTKT-110] Implement `dela deny` command to add denylist entries.
   - [ ] [DTKT-111] Implement `dela run --allow-once` command to run a command once.
 
 - [x] **Runtime Checks**

--- a/src/allowlist.rs
+++ b/src/allowlist.rs
@@ -77,10 +77,14 @@ pub fn evaluate_task_against_allowlist(task: &Task, allowlist: &Allowlist) -> Al
 
     // First pass: Check for deny entries (highest precedence)
     for entry in &allowlist.entries {
-        if let AllowScope::Deny = entry.scope
-            && path_matches(task_path, &entry.path, true)
-        {
-            return AllowlistMatch::Denied;
+        if let AllowScope::Deny = entry.scope {
+            if let Some(ref tasks) = entry.tasks {
+                if path_matches(task_path, &entry.path, false) && tasks.contains(&task.name) {
+                    return AllowlistMatch::Denied;
+                }
+            } else if path_matches(task_path, &entry.path, true) {
+                return AllowlistMatch::Denied;
+            }
         }
     }
 
@@ -113,7 +117,7 @@ pub fn evaluate_task_against_allowlist(task: &Task, allowlist: &Allowlist) -> Al
 }
 
 pub fn allowlist_entry_for_task(task: &Task, scope: AllowScope) -> AllowlistEntry {
-    let tasks = if scope == AllowScope::Task {
+    let tasks = if scope == AllowScope::Task || scope == AllowScope::Deny {
         Some(vec![task.name.clone()])
     } else {
         None
@@ -427,6 +431,36 @@ mod tests {
 
         // Task should be denied
         assert_eq!(is_task_allowed(&task).unwrap(), (false, true));
+
+        drop(temp_dir);
+        reset_to_real_environment();
+    }
+
+    #[test]
+    #[serial]
+    fn test_is_task_allowed_deny_task_scope() {
+        let (temp_dir, task) = setup_test_env();
+
+        // Create allowlist with deny scope for specific task
+        let mut allowlist = Allowlist::default();
+        let entry = AllowlistEntry {
+            path: PathBuf::from("Makefile"),
+            scope: AllowScope::Deny,
+            tasks: Some(vec!["test-task".to_string()]),
+        };
+        allowlist.entries.push(entry);
+        save_allowlist(&allowlist).unwrap();
+
+        // Task should be denied
+        assert_eq!(is_task_allowed(&task).unwrap(), (false, true));
+
+        // A different task should NOT be denied
+        let other_task = create_test_task("other-task", PathBuf::from("Makefile"));
+        assert_eq!(is_task_allowed(&other_task).unwrap(), (false, false));
+
+        // A task from a different Makefile should NOT be denied
+        let other_path_task = create_test_task("test-task", PathBuf::from("other/Makefile"));
+        assert_eq!(is_task_allowed(&other_path_task).unwrap(), (false, false));
 
         drop(temp_dir);
         reset_to_real_environment();

--- a/src/commands/allow.rs
+++ b/src/commands/allow.rs
@@ -57,7 +57,7 @@ mod tests {
 
     impl TestEnvGuard {
         fn new() -> Self {
-            let original_cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let original_cwd = env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
             let (project_dir, home_dir) = setup_test_env();
             Self {
                 project_dir,
@@ -67,7 +67,7 @@ mod tests {
         }
 
         fn new_uninitialized() -> Self {
-            let original_cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let original_cwd = env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
             // Create a temp dir for HOME but don't create the dela config directory
             let home_dir = TempDir::new().expect("Failed to create temp HOME directory");
 

--- a/src/commands/allow.rs
+++ b/src/commands/allow.rs
@@ -52,18 +52,22 @@ mod tests {
     struct TestEnvGuard {
         project_dir: TempDir,
         home_dir: TempDir,
+        original_cwd: std::path::PathBuf,
     }
 
     impl TestEnvGuard {
         fn new() -> Self {
+            let original_cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
             let (project_dir, home_dir) = setup_test_env();
             Self {
                 project_dir,
                 home_dir,
+                original_cwd,
             }
         }
 
         fn new_uninitialized() -> Self {
+            let original_cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
             // Create a temp dir for HOME but don't create the dela config directory
             let home_dir = TempDir::new().expect("Failed to create temp HOME directory");
 
@@ -74,12 +78,14 @@ mod tests {
             Self {
                 project_dir: TempDir::new().expect("Failed to create temp directory"),
                 home_dir,
+                original_cwd,
             }
         }
     }
 
     impl Drop for TestEnvGuard {
         fn drop(&mut self) {
+            let _ = env::set_current_dir(&self.original_cwd);
             reset_to_real_environment();
         }
     }

--- a/src/commands/deny.rs
+++ b/src/commands/deny.rs
@@ -131,10 +131,11 @@ test: ## Running tests
         let result = execute("test");
         assert!(result.is_ok(), "Should succeed for a single task");
 
-        // Verify it was added to the allowlist with Deny scope
+        // Verify it was added to the allowlist with Deny scope and task name
         let allowlist_content =
             fs::read_to_string(preferred_allowlist_path_for(guard.home_dir.path())).unwrap();
         assert!(allowlist_content.contains("scope = \"Deny\""));
+        assert!(allowlist_content.contains("tasks = [\"test\"]"));
     }
 
     #[test]
@@ -218,5 +219,6 @@ test: ## Running tests
         let allowlist_content =
             fs::read_to_string(preferred_allowlist_path_for(guard.home_dir.path())).unwrap();
         assert!(allowlist_content.contains("scope = \"Deny\""));
+        assert!(allowlist_content.contains("tasks = [\"test\"]"));
     }
 }

--- a/src/commands/deny.rs
+++ b/src/commands/deny.rs
@@ -57,7 +57,7 @@ mod tests {
 
     impl TestEnvGuard {
         fn new() -> Self {
-            let original_cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let original_cwd = env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
             let (project_dir, home_dir) = setup_test_env();
             Self {
                 project_dir,
@@ -67,7 +67,7 @@ mod tests {
         }
 
         fn new_uninitialized() -> Self {
-            let original_cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            let original_cwd = env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
             // Create a temp dir for HOME but don't create the dela config directory
             let home_dir = TempDir::new().expect("Failed to create temp HOME directory");
 

--- a/src/commands/deny.rs
+++ b/src/commands/deny.rs
@@ -1,0 +1,216 @@
+use crate::allowlist;
+use crate::task_discovery;
+use crate::types::AllowScope;
+use std::env;
+
+/// Executes the 'dela deny' command to add a specific task definition file to the denylist.
+pub fn execute(task_name: &str) -> anyhow::Result<()> {
+    let current_dir = env::current_dir()
+        .map_err(|e| anyhow::anyhow!("Failed to get current directory: {}", e))?;
+    let discovered = task_discovery::discover_tasks(&current_dir);
+
+    // Find all tasks with the given name (both original and disambiguated)
+    let matching_tasks = task_discovery::get_matching_tasks(&discovered, task_name);
+
+    match matching_tasks.len() {
+        0 => Err(anyhow::anyhow!(
+            "dela: command or task not found: {}",
+            task_name
+        )),
+        1 => {
+            let task = matching_tasks[0];
+            allowlist::check_task_allowed_with_scope(task, AllowScope::Deny)?;
+            println!(
+                "Denied task '{}' ({}) in allowlist.",
+                task.name,
+                task.runner.short_name()
+            );
+            Ok(())
+        }
+        _ => {
+            let error_msg = task_discovery::format_ambiguous_task_error(task_name, &matching_tasks);
+            eprintln!("{}", error_msg);
+            Err(anyhow::anyhow!(
+                "Multiple tasks named '{}' found",
+                task_name
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{preferred_allowlist_path_for, preferred_config_dir_path_for};
+    use crate::environment::{TestEnvironment, reset_to_real_environment, set_test_environment};
+    use serial_test::serial;
+    use std::env;
+    use std::fs::{self, File};
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    struct TestEnvGuard {
+        project_dir: TempDir,
+        home_dir: TempDir,
+    }
+
+    impl TestEnvGuard {
+        fn new() -> Self {
+            let (project_dir, home_dir) = setup_test_env();
+            Self {
+                project_dir,
+                home_dir,
+            }
+        }
+
+        fn new_uninitialized() -> Self {
+            // Create a temp dir for HOME but don't create the dela config directory
+            let home_dir = TempDir::new().expect("Failed to create temp HOME directory");
+
+            // Set up test environment with the temp directory as HOME
+            let test_env = TestEnvironment::new().with_home(home_dir.path().to_string_lossy());
+            set_test_environment(test_env);
+
+            Self {
+                project_dir: TempDir::new().expect("Failed to create temp directory"),
+                home_dir,
+            }
+        }
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            reset_to_real_environment();
+        }
+    }
+
+    fn setup_test_env() -> (TempDir, TempDir) {
+        // Create a temp dir for the project
+        let project_dir = TempDir::new().expect("Failed to create temp directory");
+
+        // Create a test Makefile
+        let makefile_content = "
+build: ## Building the project
+\t@echo Building...
+
+test: ## Running tests
+\t@echo Testing...
+";
+        let mut makefile =
+            File::create(project_dir.path().join("Makefile")).expect("Failed to create Makefile");
+        makefile
+            .write_all(makefile_content.as_bytes())
+            .expect("Failed to write Makefile");
+
+        // Create a temp dir for HOME and set it up
+        let home_dir = TempDir::new().expect("Failed to create temp HOME directory");
+
+        // Set up test environment with the temp directory as HOME
+        let test_env = TestEnvironment::new().with_home(home_dir.path().to_string_lossy());
+        set_test_environment(test_env);
+
+        // Create ~/.config/dela directory
+        fs::create_dir_all(preferred_config_dir_path_for(home_dir.path()))
+            .expect("Failed to create dela config directory");
+
+        (project_dir, home_dir)
+    }
+
+    #[test]
+    #[serial]
+    fn test_execute_deny_single_task() {
+        let guard = TestEnvGuard::new();
+        env::set_current_dir(&guard.project_dir).expect("Failed to change directory");
+
+        let result = execute("test");
+        assert!(result.is_ok(), "Should succeed for a single task");
+
+        // Verify it was added to the allowlist with Deny scope
+        let allowlist_content =
+            fs::read_to_string(preferred_allowlist_path_for(guard.home_dir.path())).unwrap();
+        assert!(allowlist_content.contains("scope = \"Deny\""));
+    }
+
+    #[test]
+    #[serial]
+    fn test_execute_deny_no_task() {
+        let guard = TestEnvGuard::new();
+        env::set_current_dir(&guard.project_dir).expect("Failed to change directory");
+
+        let result = execute("nonexistent");
+        assert!(result.is_err(), "Should fail for nonexistent task");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "dela: command or task not found: nonexistent"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_execute_deny_uninitialized() {
+        let guard = TestEnvGuard::new_uninitialized();
+        env::set_current_dir(&guard.project_dir).expect("Failed to change directory");
+
+        // Create a test Makefile
+        let makefile_content = "
+test: ## Running tests
+\t@echo Testing...
+";
+        let mut makefile = File::create(guard.project_dir.path().join("Makefile"))
+            .expect("Failed to create Makefile");
+        makefile
+            .write_all(makefile_content.as_bytes())
+            .expect("Failed to write Makefile");
+
+        let result = execute("test");
+        assert!(result.is_err(), "Should fail when dela is not initialized");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Dela is not initialized. Please run 'dela init' first."
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_execute_deny_disambiguated() {
+        let guard = TestEnvGuard::new();
+        env::set_current_dir(&guard.project_dir).expect("Failed to change directory");
+
+        // Create a package.json with the same task name
+        let package_json_content = r#"{
+            "name": "test-package",
+            "scripts": {
+                "test": "jest"
+            }
+        }"#;
+
+        File::create(guard.project_dir.path().join("package.json"))
+            .unwrap()
+            .write_all(package_json_content.as_bytes())
+            .unwrap();
+
+        // Create package-lock.json to ensure npm is detected
+        File::create(guard.project_dir.path().join("package-lock.json"))
+            .unwrap()
+            .write_all(b"{}")
+            .unwrap();
+
+        // Ambiguous task name 'test' should fail
+        let result = execute("test");
+        assert!(result.is_err(), "Should fail for ambiguous task name");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Multiple tasks named 'test' found")
+        );
+
+        // Suffixed/disambiguated task name should succeed
+        let result = execute("test-m");
+        assert!(result.is_ok(), "Should succeed with disambiguated name");
+
+        let allowlist_content =
+            fs::read_to_string(preferred_allowlist_path_for(guard.home_dir.path())).unwrap();
+        assert!(allowlist_content.contains("scope = \"Deny\""));
+    }
+}

--- a/src/commands/deny.rs
+++ b/src/commands/deny.rs
@@ -52,18 +52,22 @@ mod tests {
     struct TestEnvGuard {
         project_dir: TempDir,
         home_dir: TempDir,
+        original_cwd: std::path::PathBuf,
     }
 
     impl TestEnvGuard {
         fn new() -> Self {
+            let original_cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
             let (project_dir, home_dir) = setup_test_env();
             Self {
                 project_dir,
                 home_dir,
+                original_cwd,
             }
         }
 
         fn new_uninitialized() -> Self {
+            let original_cwd = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
             // Create a temp dir for HOME but don't create the dela config directory
             let home_dir = TempDir::new().expect("Failed to create temp HOME directory");
 
@@ -74,12 +78,14 @@ mod tests {
             Self {
                 project_dir: TempDir::new().expect("Failed to create temp directory"),
                 home_dir,
+                original_cwd,
             }
         }
     }
 
     impl Drop for TestEnvGuard {
         fn drop(&mut self) {
+            let _ = env::set_current_dir(&self.original_cwd);
             reset_to_real_environment();
         }
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod allow;
 pub mod allow_command;
 pub mod configure_shell;
+pub mod deny;
 pub mod get_command;
 pub mod init;
 pub mod list;

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,16 @@ enum Commands {
         task: String,
     },
 
+    /// Deny a specific task from running
+    ///
+    /// This adds the task's definition file to the allowlist at the Deny scope.
+    ///
+    /// Example: dela deny build
+    Deny {
+        /// Name of the task to deny
+        task: String,
+    },
+
     // Internal commands (hidden from help by default)
     #[command(name = "configure-shell", hide = true)]
     ConfigureShell,
@@ -194,6 +204,7 @@ async fn run_command(command: Commands) -> anyhow::Result<()> {
         Commands::List { verbose, color } => commands::list::execute(verbose, &color),
         Commands::Run { task } => commands::run::execute(&task),
         Commands::Allow { task } => commands::allow::execute(&task),
+        Commands::Deny { task } => commands::deny::execute(&task),
         Commands::GetCommand { args } => {
             if args.is_empty() {
                 Err(anyhow::anyhow!("No task name provided"))

--- a/tests/docker_noinit/test_noinit.sh
+++ b/tests/docker_noinit/test_noinit.sh
@@ -888,6 +888,59 @@ dela allow test-m >/dev/null 2>&1 || {
 }
 echo "${GREEN}✓ dela allow test-m (disambiguated name) succeeded as expected${NC}"
 
+# Test 32: Test 'dela deny' command functionality
+echo "\nTest 32: Testing 'dela deny' command functionality"
+
+# Deny a single valid task
+dela deny another-task >/dev/null 2>&1 || {
+    echo "${RED}✗ dela deny another-task failed${NC}"
+    exit 1
+}
+
+# Verify Makefile was added to the allowlist with Deny scope in an entry-aware way
+if python3 -c '
+import sys
+content = open("/home/testuser/.config/dela/allowlist.toml").read()
+for entry in content.split("[[entries]]"):
+    if "Makefile" in entry and "scope = \"Deny\"" in entry:
+        sys.exit(0)
+sys.exit(1)
+'; then
+    echo "${GREEN}✓ Makefile was added to allowlist with Deny scope via dela deny command${NC}"
+else
+    echo "${RED}✗ Makefile was not added to allowlist with Deny scope via dela deny command${NC}"
+    exit 1
+fi
+
+# Now running any task from Makefile should fail because the Makefile is denied.
+# We can verify that dela allow-command on 'another-task' fails and outputs a denial message.
+output=$(dela allow-command another-task 2>&1 || true)
+if echo "$output" | grep -q "was denied by the allowlist"; then
+    echo "${GREEN}✓ Task from denied Makefile was blocked as expected${NC}"
+else
+    echo "${RED}✗ Task from denied Makefile was not blocked${NC}"
+    echo "Output: $output"
+    exit 1
+fi
+
+# Verify dela deny fails for nonexistent task
+if dela deny nonexistent >/dev/null 2>&1; then
+    echo "${RED}✗ dela deny nonexistent succeeded but should have failed${NC}"
+    exit 1
+else
+    echo "${GREEN}✓ dela deny nonexistent failed as expected${NC}"
+fi
+
+# Verify dela deny fails for ambiguous tasks
+# We have duplicate_test.json and duplicate_test.mk still present in the directory.
+# So 'test' is ambiguous.
+if dela deny test >/dev/null 2>&1; then
+    echo "${RED}✗ dela deny test (ambiguous) succeeded but should have failed${NC}"
+    exit 1
+else
+    echo "${GREEN}✓ dela deny test (ambiguous) failed as expected${NC}"
+fi
+
 # Clean up test files
 rm -f duplicate_test.json duplicate_test.mk list_output.txt list_output_long.txt
 

--- a/tests/docker_noinit/test_noinit.sh
+++ b/tests/docker_noinit/test_noinit.sh
@@ -914,22 +914,33 @@ fi
 
 # Now running the denied task another-task should fail because it is denied.
 # We can verify that dela allow-command on 'another-task' fails and outputs a denial message.
-output=$(dela allow-command another-task 2>&1 || true)
+exit_code=0
+output=$(dela allow-command another-task 2>&1) || exit_code=$?
+if [ $exit_code -eq 0 ]; then
+    echo "${RED}✗ Denied task another-task did not fail (exited with 0)${NC}"
+    exit 1
+fi
 if echo "$output" | grep -q "was denied by the allowlist"; then
-    echo "${GREEN}✓ Denied task another-task was blocked as expected${NC}"
+    echo "${GREEN}✓ Denied task another-task was blocked as expected (exit code: $exit_code)${NC}"
 else
-    echo "${RED}✗ Denied task another-task was not blocked${NC}"
+    echo "${RED}✗ Denied task another-task was not blocked with the expected message${NC}"
     echo "Output: $output"
     exit 1
 fi
 
 # Verify that another task from the same Makefile (like print-args) is NOT blocked as denied
-output_other=$(dela allow-command print-args 2>&1 || true)
+exit_code_other=0
+output_other=$(dela allow-command print-args 2>&1) || exit_code_other=$?
+if [ $exit_code_other -ne 0 ]; then
+    echo "${RED}✗ Allowed task print-args failed with exit code $exit_code_other${NC}"
+    echo "Output: $output_other"
+    exit 1
+fi
 if echo "$output_other" | grep -q "was denied by the allowlist"; then
     echo "${RED}✗ Other task print-args in the same Makefile was blocked as denied, but it should not be${NC}"
     exit 1
 else
-    echo "${GREEN}✓ Other task print-args in the same Makefile was not blocked as denied${NC}"
+    echo "${GREEN}✓ Other task print-args in the same Makefile was not blocked as denied (exit code: $exit_code_other)${NC}"
 fi
 
 # Verify dela deny fails for nonexistent task

--- a/tests/docker_noinit/test_noinit.sh
+++ b/tests/docker_noinit/test_noinit.sh
@@ -897,30 +897,39 @@ dela deny another-task >/dev/null 2>&1 || {
     exit 1
 }
 
-# Verify Makefile was added to the allowlist with Deny scope in an entry-aware way
+# Verify Makefile was added to the allowlist with Deny scope and task name in an entry-aware way
 if python3 -c '
 import sys
 content = open("/home/testuser/.config/dela/allowlist.toml").read()
 for entry in content.split("[[entries]]"):
-    if "Makefile" in entry and "scope = \"Deny\"" in entry:
+    if "Makefile" in entry and "scope = \"Deny\"" in entry and "tasks = [\"another-task\"]" in entry:
         sys.exit(0)
 sys.exit(1)
 '; then
-    echo "${GREEN}✓ Makefile was added to allowlist with Deny scope via dela deny command${NC}"
+    echo "${GREEN}✓ Makefile was added to allowlist with Deny scope and tasks = [\"another-task\"] via dela deny command${NC}"
 else
-    echo "${RED}✗ Makefile was not added to allowlist with Deny scope via dela deny command${NC}"
+    echo "${RED}✗ Makefile was not added to allowlist with Deny scope and tasks = [\"another-task\"] via dela deny command${NC}"
     exit 1
 fi
 
-# Now running any task from Makefile should fail because the Makefile is denied.
+# Now running the denied task another-task should fail because it is denied.
 # We can verify that dela allow-command on 'another-task' fails and outputs a denial message.
 output=$(dela allow-command another-task 2>&1 || true)
 if echo "$output" | grep -q "was denied by the allowlist"; then
-    echo "${GREEN}✓ Task from denied Makefile was blocked as expected${NC}"
+    echo "${GREEN}✓ Denied task another-task was blocked as expected${NC}"
 else
-    echo "${RED}✗ Task from denied Makefile was not blocked${NC}"
+    echo "${RED}✗ Denied task another-task was not blocked${NC}"
     echo "Output: $output"
     exit 1
+fi
+
+# Verify that another task from the same Makefile (like print-args) is NOT blocked as denied
+output_other=$(dela allow-command print-args 2>&1 || true)
+if echo "$output_other" | grep -q "was denied by the allowlist"; then
+    echo "${RED}✗ Other task print-args in the same Makefile was blocked as denied, but it should not be${NC}"
+    exit 1
+else
+    echo "${GREEN}✓ Other task print-args in the same Makefile was not blocked as denied${NC}"
 fi
 
 # Verify dela deny fails for nonexistent task


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to deny/block specified tasks with name resolution and ambiguity handling; updates the allowlist and prints clear success/error messages.
  * Allowlist now supports task-scoped deny entries (deny applies only to listed task names when scoped).

* **Tests**
  * Added unit and integration tests (including shell integration) for deny behavior, ambiguity handling, and allowlist effects; improved test environment isolation to restore working directory.

* **Documentation**
  * Marked the deny task item as completed in project docs.

* **Chores**
  * Updated baseline metrics/report entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aleyan/dela/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->