### PR TITLE
Require rust 1.93.0 and bump the baseline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
     needs: verify-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e6721ae0bf5283f0e981fb97b8a7af9 # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
 
       - name: Verify release metadata
         id: release_meta
@@ -65,12 +65,12 @@ jobs:
     needs: verify-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e6721ae0bf5283f0e981fb97b8a7af9 # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           components: rustfmt, clippy
 
       - name: Run lint
@@ -102,7 +102,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
 
       - name: Validate publish package
         run: cargo publish --dry-run --locked
@@ -138,7 +138,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           targets: ${{ matrix.target }}
 
       - name: Install Linux cross-compilation tools
@@ -234,7 +234,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
 
       - name: Check whether version is already published
         id: crates_version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: 1.91.1
+          toolchain: 1.93.0
           components: rustfmt, clippy
       
       - name: Cache dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dela"
 version = "0.0.6"
-rust-version = "1.91.1"
+rust-version = "1.93.0"
 edition = "2024"
 license = "MIT"
 authors = ["Alexander Yankov"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build tests tests_integration test_unit test_noinit test_mcp test_zsh test_bash test_fish test_pwsh run install
 
 SHELL := /bin/bash
+export RUSTUP_TOOLCHAIN=1.93.0
 
 # Default to non-verbose output
 VERBOSE ?= 0

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dela is a task runner that provides discovery for task definitions in various fo
 Install `dela` from crates.io and initialize it to set up shell integration:
 
 ```sh
-$ cargo install dela
+$ cargo +1.93.0 install dela
 $ dela init
 ```
 

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -159,16 +159,16 @@
       "function": "discover_github_actions_tasks",
       "line": 17,
       "cyclomatic": 19.0,
-      "coverage": 88.88888888888889,
-      "crap": 19.49519890260631
+      "coverage": 90.0,
+      "crap": 19.361
     },
     {
       "file": "./src/task_discovery/taskfile.rs",
       "function": "collect_taskfile_tasks_recursive",
       "line": 90,
       "cyclomatic": 19.0,
-      "coverage": 94.73684210526315,
-      "crap": 19.05263157894737
+      "coverage": 94.5945945945946,
+      "crap": 19.05701537914832
     },
     {
       "file": "./src/types.rs",
@@ -183,8 +183,8 @@
       "function": "execute",
       "line": 100,
       "cyclomatic": 18.0,
-      "coverage": 87.03703703703704,
-      "crap": 18.70576131687243
+      "coverage": 88.0,
+      "crap": 18.559872
     },
     {
       "file": "./src/allowlist.rs",
@@ -231,8 +231,8 @@
       "function": "add_shell_integration",
       "line": 50,
       "cyclomatic": 16.0,
-      "coverage": 87.87878787878788,
-      "crap": 16.45590895177672
+      "coverage": 93.75,
+      "crap": 16.0625
     },
     {
       "file": "./src/commands/list.rs",
@@ -355,25 +355,25 @@
       "crap": 10.885645167903563
     },
     {
-      "file": "./src/parsers/parse_gradle.rs",
-      "function": "extract_task_description",
-      "line": 132,
-      "cyclomatic": 10.0,
-      "coverage": 85.71428571428571,
-      "crap": 10.291545189504374
-    },
-    {
       "file": "./src/prompt.rs",
       "function": "prompt_for_task_fallback",
       "line": 68,
       "cyclomatic": 10.0,
-      "coverage": 90.32258064516128,
-      "crap": 10.090631398744588
+      "coverage": 90.0,
+      "crap": 10.1
     },
     {
       "file": "./src/parsers/parse_gradle.rs",
       "function": "extract_custom_tasks",
       "line": 63,
+      "cyclomatic": 10.0,
+      "coverage": 100.0,
+      "crap": 10.0
+    },
+    {
+      "file": "./src/parsers/parse_gradle.rs",
+      "function": "extract_task_description",
+      "line": 132,
       "cyclomatic": 10.0,
       "coverage": 100.0,
       "crap": 10.0
@@ -571,14 +571,6 @@
       "crap": 6.5625
     },
     {
-      "file": "./src/runners/runners_pyproject_toml.rs",
-      "function": "detect_package_manager",
-      "line": 21,
-      "cyclomatic": 6.0,
-      "coverage": 80.76923076923077,
-      "crap": 6.256030951297223
-    },
-    {
       "file": "./src/allowlist.rs",
       "function": "save_allowlist",
       "line": 40,
@@ -593,6 +585,14 @@
       "cyclomatic": 6.0,
       "coverage": 93.54838709677419,
       "crap": 6.009667349199423
+    },
+    {
+      "file": "./src/runners/runners_pyproject_toml.rs",
+      "function": "detect_package_manager",
+      "line": 21,
+      "cyclomatic": 6.0,
+      "coverage": 95.83333333333334,
+      "crap": 6.002604166666667
     },
     {
       "file": "./src/task_discovery/shell_scripts.rs",
@@ -939,14 +939,6 @@
       "crap": 4.0
     },
     {
-      "file": "./src/commands/mod.rs",
-      "function": "gate_non_interactive",
-      "line": 16,
-      "cyclomatic": 3.0,
-      "coverage": 75.0,
-      "crap": 3.140625
-    },
-    {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::send_log",
       "line": 201,
@@ -1126,6 +1118,14 @@
       "file": "./src/commands/list.rs",
       "function": "task_source_label",
       "line": 337,
+      "cyclomatic": 3.0,
+      "coverage": 100.0,
+      "crap": 3.0
+    },
+    {
+      "file": "./src/commands/mod.rs",
+      "function": "gate_non_interactive",
+      "line": 17,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.93.0"
 components = ["rustfmt", "clippy"]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -369,4 +369,22 @@ mod tests {
 
         reset_to_real_environment();
     }
+
+    #[test]
+    #[serial]
+    fn test_add_shell_integration_error() {
+        let temp_dir = TempDir::new().unwrap();
+        setup_test_env("/bin/zsh", &temp_dir.path().to_path_buf()).unwrap();
+
+        // Pass a directory path as config_path to force a read error (EISDIR)
+        let result = add_shell_integration(&temp_dir.path().to_path_buf());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to read shell config"));
+
+        reset_to_real_environment();
+    }
 }
+

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -374,17 +374,19 @@ mod tests {
     #[serial]
     fn test_add_shell_integration_error() {
         let temp_dir = TempDir::new().unwrap();
-        setup_test_env("/bin/zsh", &temp_dir.path().to_path_buf()).unwrap();
+        setup_test_env("/bin/zsh", temp_dir.path()).unwrap();
 
         // Pass a directory path as config_path to force a read error (EISDIR)
-        let result = add_shell_integration(&temp_dir.path().to_path_buf());
+        let config_path = temp_dir.path().to_path_buf();
+        let result = add_shell_integration(&config_path);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to read shell config"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to read shell config")
+        );
 
         reset_to_real_environment();
     }
 }
-

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -63,4 +63,3 @@ mod tests {
         assert!(result.is_ok());
     }
 }
-

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,12 +9,22 @@ pub mod mcp;
 pub mod run;
 pub mod run_command;
 
+#[cfg(not(test))]
 use std::io::IsTerminal;
 
 /// Returns an error if the current session is non-interactive (no TTY).
 /// This prevents scripts and agents from running `dela allow` / `dela deny`.
 pub(crate) fn gate_non_interactive(command_name: &str) -> anyhow::Result<()> {
-    let is_terminal = std::io::stdout().is_terminal() && std::io::stdin().is_terminal();
+    let is_terminal = {
+        #[cfg(test)]
+        {
+            std::env::var("DELA_SIMULATE_TERMINAL").is_ok()
+        }
+        #[cfg(not(test))]
+        {
+            std::io::stdout().is_terminal() && std::io::stdin().is_terminal()
+        }
+    };
     if !is_terminal {
         anyhow::bail!(
             "'{}' should only be run by human users directly, and not by scripts or agents.",
@@ -27,8 +37,10 @@ pub(crate) fn gate_non_interactive(command_name: &str) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_gate_non_interactive_in_test_env() {
         let result = gate_non_interactive("dela allow");
         assert!(result.is_err());
@@ -37,4 +49,18 @@ mod tests {
             "'dela allow' should only be run by human users directly, and not by scripts or agents."
         );
     }
+
+    #[test]
+    #[serial]
+    fn test_gate_non_interactive_simulated_terminal() {
+        unsafe {
+            std::env::set_var("DELA_SIMULATE_TERMINAL", "1");
+        }
+        let result = gate_non_interactive("dela allow");
+        unsafe {
+            std::env::remove_var("DELA_SIMULATE_TERMINAL");
+        }
+        assert!(result.is_ok());
+    }
 }
+

--- a/src/parsers/parse_gradle.rs
+++ b/src/parsers/parse_gradle.rs
@@ -137,7 +137,7 @@ fn extract_task_description(content: &str, task_name: &str) -> Option<String> {
 
     // Look for task with description using single quotes
     if let Ok(regex) = Regex::new(&format!(
-        "{}.+?{}",
+        "(?s){}.+?{}",
         task_pattern, description_single_quote_pattern
     )) && let Some(caps) = regex.captures(content)
         && let Some(desc) = caps.get(1)
@@ -147,7 +147,7 @@ fn extract_task_description(content: &str, task_name: &str) -> Option<String> {
 
     // Look for task with description using double quotes
     if let Ok(regex) = Regex::new(&format!(
-        "{}.+?{}",
+        "(?s){}.+?{}",
         task_pattern, description_double_quote_pattern
     )) && let Some(caps) = regex.captures(content)
         && let Some(desc) = caps.get(1)
@@ -157,7 +157,7 @@ fn extract_task_description(content: &str, task_name: &str) -> Option<String> {
 
     // For Kotlin DSL, look for description with equals
     let kotlin_pattern = format!(
-        r#"tasks.*?"{}".+?description\s*=\s*"([^"]*)""#,
+        r#"(?s)tasks.*?"{}".+?description\s*=\s*"([^"]*)""#,
         regex::escape(task_name)
     );
     if let Ok(regex) = Regex::new(&kotlin_pattern)
@@ -274,6 +274,13 @@ task customTask {
     }
 }
 
+task doubleQuoteTask {
+    description "A double quote task description"
+    doLast {
+        println 'Hello'
+    }
+}
+
 task anotherTask(type: Copy) {
     from 'src'
     into 'build/copied'
@@ -300,12 +307,18 @@ application {
 
         // Check for custom tasks
         assert!(tasks.iter().any(|t| t.name == "customTask"));
+        assert!(tasks.iter().any(|t| t.name == "doubleQuoteTask"));
         assert!(tasks.iter().any(|t| t.name == "anotherTask"));
 
-        // Verify at least one custom task
+        // Verify custom task descriptions
         let custom_task = tasks.iter().find(|t| t.name == "customTask").unwrap();
-        assert_eq!(custom_task.definition_type, TaskDefinitionType::Gradle);
-        assert_eq!(custom_task.runner, TaskRunner::Gradle);
+        assert_eq!(custom_task.description, Some("A custom task".to_string()));
+
+        let double_quote_task = tasks.iter().find(|t| t.name == "doubleQuoteTask").unwrap();
+        assert_eq!(double_quote_task.description, Some("A double quote task description".to_string()));
+
+        let another_task = tasks.iter().find(|t| t.name == "anotherTask").unwrap();
+        assert_eq!(another_task.description, Some("Custom Gradle task".to_string()));
     }
 
     #[test]
@@ -330,6 +343,7 @@ dependencies {
 }
 
 tasks.register<Copy>("copyDocs") {
+    description = "Some copy task description"
     from("src/docs")
     into("build/docs")
 }
@@ -360,18 +374,14 @@ application {
         assert!(tasks.iter().any(|t| t.name == "test"));
 
         // Check for plugin tasks
-        // No longer checking for Spring Boot plugin tasks that may not be present
-        // assert!(tasks.iter().any(|t| t.name == "bootRun"));
-        // assert!(tasks.iter().any(|t| t.name == "bootJar"));
         assert!(tasks.iter().any(|t| t.name == "compileKotlin"));
 
         // Check for custom tasks
         assert!(tasks.iter().any(|t| t.name == "copyDocs"));
         assert!(tasks.iter().any(|t| t.name == "customKotlinTask"));
 
-        // Verify at least one custom task
-        let custom_task = tasks.iter().find(|t| t.name == "copyDocs").unwrap();
-        assert_eq!(custom_task.definition_type, TaskDefinitionType::Gradle);
-        assert_eq!(custom_task.runner, TaskRunner::Gradle);
+        // Verify Kotlin description
+        let copy_docs = tasks.iter().find(|t| t.name == "copyDocs").unwrap();
+        assert_eq!(copy_docs.description, Some("Some copy task description".to_string()));
     }
 }

--- a/src/parsers/parse_gradle.rs
+++ b/src/parsers/parse_gradle.rs
@@ -315,10 +315,16 @@ application {
         assert_eq!(custom_task.description, Some("A custom task".to_string()));
 
         let double_quote_task = tasks.iter().find(|t| t.name == "doubleQuoteTask").unwrap();
-        assert_eq!(double_quote_task.description, Some("A double quote task description".to_string()));
+        assert_eq!(
+            double_quote_task.description,
+            Some("A double quote task description".to_string())
+        );
 
         let another_task = tasks.iter().find(|t| t.name == "anotherTask").unwrap();
-        assert_eq!(another_task.description, Some("Custom Gradle task".to_string()));
+        assert_eq!(
+            another_task.description,
+            Some("Custom Gradle task".to_string())
+        );
     }
 
     #[test]
@@ -382,6 +388,9 @@ application {
 
         // Verify Kotlin description
         let copy_docs = tasks.iter().find(|t| t.name == "copyDocs").unwrap();
-        assert_eq!(copy_docs.description, Some("Some copy task description".to_string()));
+        assert_eq!(
+            copy_docs.description,
+            Some("Some copy task description".to_string())
+        );
     }
 }

--- a/src/runners/runners_pyproject_toml.rs
+++ b/src/runners/runners_pyproject_toml.rs
@@ -217,4 +217,51 @@ mod tests {
 
         reset_to_real_environment();
     }
+
+    #[test]
+    #[serial]
+    fn test_detect_package_manager_with_poe() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Reset and enable mock system
+        reset_mock();
+        enable_mock();
+
+        // Set up test environment with poe only
+        let env = TestEnvironment::new().with_executable("poe");
+        set_test_environment(env);
+
+        // Mock poe being available
+        mock_executable("poe");
+
+        let result = detect_package_manager(temp_dir.path());
+        assert_eq!(result, Some(TaskRunner::PythonPoe));
+
+        // Clean up
+        reset_mock();
+        reset_to_real_environment();
+    }
+
+    #[test]
+    #[serial]
+    fn test_detect_package_manager_none() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Reset and enable mock system
+        reset_mock();
+        enable_mock();
+
+        // Set up test environment with NO executables
+        let env = TestEnvironment::new();
+        set_test_environment(env);
+
+        let result = detect_package_manager(temp_dir.path());
+        assert_eq!(result, None);
+
+        // Clean up
+        reset_mock();
+        reset_to_real_environment();
+    }
 }
+
+

--- a/src/runners/runners_pyproject_toml.rs
+++ b/src/runners/runners_pyproject_toml.rs
@@ -263,5 +263,3 @@ mod tests {
         reset_to_real_environment();
     }
 }
-
-

--- a/tests/Dockerfile.builder
+++ b/tests/Dockerfile.builder
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # --- Stage 1: Builder ---
-FROM rust:1.91.1-alpine3.21 AS builder
+FROM rust:1.93.0-alpine3.21 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache \

--- a/tests/docker_unit/Dockerfile
+++ b/tests/docker_unit/Dockerfile
@@ -2,7 +2,7 @@
 FROM dela-builder AS builder
 
 # Test environment
-FROM rust:1.91.1-alpine3.21
+FROM rust:1.93.0-alpine3.21
 
 # Install build dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain to 1.93.0 across CI, build configs, Makefile and Docker images.
  * Adjusted installation instructions to use the pinned toolchain.
  * Updated internal baseline report data.

* **Bug Fixes**
  * Gradle task description parsing now handles multi-line and Kotlin/Groovy variants.
  * Refined terminal interactivity checks for test runs.

* **Tests**
  * Added tests for shell integration error handling and Python package-manager detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->