### PR TITLE
mcp: separate stdout/stderr output chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Tool names are stable, and `list_tasks` exposes a stable wire format (including 
 | `status` | List all currently running background tasks |
 | `task_start` | Start a task by unique name with optional args/env/cwd |
 | `task_status` | Get status for running instances of a specific task |
-| `task_output` | Get the last N lines of output for a running task (by PID) |
+| `task_output` | Get stream-aware output chunks for a task by PID, with optional offset paging |
 | `task_stop` | Stop a running task by PID (SIGTERM + grace period + SIGKILL) |
 
 ### Security

--- a/dev_docs/mcp_design.md
+++ b/dev_docs/mcp_design.md
@@ -84,7 +84,7 @@ Libraries and their roles:
 - **PID-centric**: Each started task is a real OS child process with a PID.
 - **Default capture window**: `task_start` collects stdout/stderr for up to **1 second** by default.
   - If the child exits in ≤1s → return `{ state: "exited", exit_code, output }`.
-  - If still running after 1s → background it and return `{ state: "running", pid, initial_output }`.
+  - If still running after 1s → background it and return `{ state: "running", pid, output }`.
 - **Bounded wait execution**: callers can pass `task_start(wait_for_exit_seconds=N)` to extend
   that wait window for short/medium tasks like tests and builds. If the task exits within the
   requested window, `task_start` returns final status and captured output in one round trip. If it
@@ -127,11 +127,18 @@ pub struct TaskStartArgs {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct OutputChunkDto {
+  pub stdout: Option<String>,  // present for stdout chunks
+  pub stderr: Option<String>,  // present for stderr chunks
+}
+
+#[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct StartResultDto {
   pub state: String,            // "exited"|"running"|"failed"
   pub pid: Option<i32>,         // present if running
   pub exit_code: Option<i32>,   // present if exited/failed
-  pub initial_output: String,   // combined stdout+stderr captured before returning
+  pub output: Vec<OutputChunkDto>, // stream-aware chunks captured before returning
+  pub initial_output: Vec<OutputChunkDto>, // same stream-aware chunks, kept under the historical field name
 }
 
 // Note: RunningTaskDto, TaskStatusArgs, TaskOutputArgs, TaskStopArgs are Phase 2
@@ -214,7 +221,7 @@ pub struct TaskOutputArgs {
   "content": [
     {
       "type": "text",
-      "text": "{\"state\": \"exited\", \"exit_code\": 0, \"initial_output\": \"Test task executed successfully\\n\"}"
+      "text": "{\"state\":\"exited\",\"exit_code\":0,\"output\":[{\"stdout\":\"Test task executed successfully\\n\"}],\"initial_output\":[{\"stdout\":\"Test task executed successfully\\n\"}]}"
     }
   ]
 }
@@ -225,7 +232,7 @@ pub struct TaskOutputArgs {
   "content": [
     {
       "type": "text",
-      "text": "{\"state\": \"running\", \"pid\": 12345, \"initial_output\": \"Starting long-running task...\\n\"}"
+      "text": "{\"state\":\"running\",\"pid\":12345,\"output\":[{\"stdout\":\"Starting long-running task...\\n\"}],\"initial_output\":[{\"stdout\":\"Starting long-running task...\\n\"}]}"
     }
   ]
 }

--- a/dev_docs/mcp_design.md
+++ b/dev_docs/mcp_design.md
@@ -27,6 +27,11 @@ per response/notification.
 
 # Dela MCP — Revised Design (First-Principles)
 
+## API Evolution
+
+Expose the best current MCP shape. Do not keep superseded fields for compatibility; coding agents start fresh sessions and do not build long-lived programs against this API.
+
+
 ## Scope (tool surface)
 
 This redesign narrows each tool to a single, clear responsibility and aligns with how editors/agents actually consume MCP. All names are stable and self-descriptive.
@@ -44,7 +49,7 @@ This redesign narrows each tool to a single, clear responsibility and aligns wit
 - **status** → Return a list of **all running tasks** (across all names) with PIDs and minimal status.
 - **task_start** → Start a task by **unique_name** with optional args/env/cwd. If it **finishes within 1s**, return its full output and exit status. If it **does not finish in 1s**, background it, return `running` with PID and any output captured during that first second.
 - **task_status** → Return status for instances of a given **unique_name**. There may be multiple PIDs if the same task was started with different arguments. The wire format includes state, elapsed time, and completion metadata (`exit_code`, `completed_at`) so clients do not need to infer outcomes from notifications alone.
-- **task_output** → Return the **last N lines** of output for a **PID** (with a default N). Supports simple paging via an optional `from` byte cursor (future).
+- **task_output** → Return stream-aware output chunks for a **PID**. Defaults to the last N retained chunks and supports simple paging with `offset` plus `lines`.
 - **task_stop** → Stop a running task by **PID** (TERM with grace, then KILL on timeout).
 - 
 ⸻
@@ -89,7 +94,7 @@ Libraries and their roles:
   that wait window for short/medium tasks like tests and builds. If the task exits within the
   requested window, `task_start` returns final status and captured output in one round trip. If it
   is still running when the window expires, MCP backgrounds it and returns `running` with the PID.
-- **Output ring buffer**: Per-PID bounded buffer (default 1000 lines, 5 MB). `task_output` returns last N lines. Future paging via `from` byte cursor.
+- **Output ring buffer**: Per-PID bounded buffer (default 10,000 lines, 5 MB). `task_output` returns stream-aware chunks and supports retained-buffer paging with `offset` plus `lines`.
 - **Lifecycle**: `task_stop` sends SIGTERM, waits grace (default 5s), then SIGKILL. Background jobs are GC'd after a TTL (configurable).
 - **Real-time streaming**: Task output is streamed via MCP logging notifications. Clients can subscribe to `notifications/message` to receive output as it happens.
 
@@ -138,14 +143,11 @@ pub struct StartResultDto {
   pub pid: Option<i32>,         // present if running
   pub exit_code: Option<i32>,   // present if exited/failed
   pub output: Vec<OutputChunkDto>, // stream-aware chunks captured before returning
-  pub initial_output: Vec<OutputChunkDto>, // same stream-aware chunks, kept under the historical field name
 }
 
-// Note: RunningTaskDto, TaskStatusArgs, TaskOutputArgs, TaskStopArgs are Phase 2
-// and not yet implemented in the current version.
 ```
 
-Planned DTO enrichments for client ergonomics:
+Additional DTOs:
 
 ```rust
 pub struct TaskStatusJobDto {
@@ -160,8 +162,8 @@ pub struct TaskStatusJobDto {
 pub struct TaskOutputArgs {
   pub pid: u32,
   pub lines: Option<usize>,
+  pub offset: Option<usize>,       // zero-based offset into the retained output buffer
   pub show_truncation: Option<bool>,
-  pub from: Option<u64>,           // future cursor for incremental paging
 }
 ```
 
@@ -221,7 +223,7 @@ pub struct TaskOutputArgs {
   "content": [
     {
       "type": "text",
-      "text": "{\"state\":\"exited\",\"exit_code\":0,\"output\":[{\"stdout\":\"Test task executed successfully\\n\"}],\"initial_output\":[{\"stdout\":\"Test task executed successfully\\n\"}]}"
+      "text": "{\"state\":\"exited\",\"exit_code\":0,\"output\":[{\"stdout\":\"Test task executed successfully\\n\"}]}"
     }
   ]
 }
@@ -232,7 +234,7 @@ pub struct TaskOutputArgs {
   "content": [
     {
       "type": "text",
-      "text": "{\"state\":\"running\",\"pid\":12345,\"output\":[{\"stdout\":\"Starting long-running task...\\n\"}],\"initial_output\":[{\"stdout\":\"Starting long-running task...\\n\"}]}"
+      "text": "{\"state\":\"running\",\"pid\":12345,\"output\":[{\"stdout\":\"Starting long-running task...\\n\"}]}"
     }
   ]
 }
@@ -374,16 +376,16 @@ polling clients can determine completion without depending on logging notificati
   "content": [
     {
       "type": "text",
-      "text": "{\"pid\": 12345, \"lines\": [\"Building...\", \"Compiling...\"], \"total_lines\": 2, \"total_bytes\": 25, \"truncated\": false, \"buffer_full\": false}"
+      "text": "{\"pid\":12345,\"output\":[{\"stdout\":\"Building...\"},{\"stderr\":\"warning: slow compile\"}],\"offset\":0,\"next_offset\":2,\"total_lines\":2,\"total_bytes\":33,\"truncated\":false,\"buffer_full\":false}"
     }
   ]
 }
 ```
-**Planned paging form**
+**Offset paging form**
 ```json
-{ "pid": 12345, "from": 4096, "lines": 100 }
+{ "pid": 12345, "offset": 1000, "lines": 500 }
 ```
-Cursor-based paging lets clients fetch only new output instead of repeatedly re-reading a tail and diffing it client-side.
+Offset paging lets clients read a specific window from the currently retained buffer. For example, `offset: 1000, lines: 500` returns up to 500 chunks starting at retained chunk offset 1000. Responses include `next_offset` for the next request.
 
 ### 6) task_stop
 **Args**
@@ -407,7 +409,7 @@ Cursor-based paging lets clients fetch only new output instead of repeatedly re-
 ## Resources (Optional / Future)
 - We can keep a conservative tool-only design. If needed for streaming or snapshots later:
   - `job://<pid>` → JSON status snapshot
-  - `joblog://<pid>?from=<u64>` → chunked logs paging
+  - `joblog://<pid>?offset=<usize>` → chunked logs paging
 
 ## Client Ergonomics Roadmap
 
@@ -415,7 +417,7 @@ These are not required for the minimal MCP surface, but they materially improve 
 
 - **Bounded wait on start**: implemented via `task_start(wait_for_exit_seconds=...)` to avoid poll loops for common commands like tests and builds.
 - **Completion metadata in `task_status`**: implemented so clients can read `exit_code` and `completed_at` directly from polling responses.
-- **Incremental log paging**: add `from` cursors to `task_output` or `joblog://` resources.
+- **Incremental log paging**: implemented for `task_output` with `offset` plus `lines`; resources can mirror this later if needed.
 - **Discovery caching**: cache task discovery for hot paths such as repeated `list_tasks` calls.
 - **Workspace-aware editor config generation**: allow generated MCP configs to pre-bind `cwd`,
   prefer absolute `dela` binary paths when useful, and reduce post-generation manual edits.
@@ -467,19 +469,19 @@ impl ServerHandler for DelaMcpServer {
 - Validates task exists and is allowlisted
 - Checks runner availability
 - Captures output for first second, then backgrounds if still running
-- Returns `StartResultDto` with state, PID, exit code, and initial output
-- Future ergonomic extension: support bounded waiting for completion in the same call
+- Returns `StartResultDto` with state, PID, exit code, and captured output
+- Supports bounded waiting for completion in the same call via `wait_for_exit_seconds`
 
 **task_status** - Returns status for running instances of a specific task
 - Filters jobs by unique_name
 - Returns all PIDs associated with that task name
 - Includes state (running/exited/failed), elapsed_seconds, command, args, `exit_code`, and `completed_at`
 
-**task_output** - Returns the last N lines of output for a running task
+**task_output** - Returns stream-aware output chunks for a running task
 - Default 200 lines, configurable via `lines` parameter
+- Optional `offset` returns a window from the currently retained buffer
 - Supports `show_truncation` flag to indicate if output was truncated
-- Per-PID ring buffer (1000 lines, 5MB max)
-- Planned enrichment: support cursor-based paging via `from`
+- Per-PID ring buffer (10,000 lines, 5MB max)
 
 **task_stop** - Stops a running task by PID
 - Sends SIGTERM with configurable grace period (default 5s)
@@ -495,7 +497,7 @@ impl ServerHandler for DelaMcpServer {
 - Spawn via `tokio::process::Command` with stdin closed; capture stdout/stderr
 - First-second capture using `tokio::time::timeout` around a pump loop
 - Per-PID ring buffer (VecDeque) with configurable limits:
-  - Max 1000 lines per job
+  - Max 10,000 lines per job
   - Max 5MB output per job
 - Job metadata includes: started_at (internal), elapsed_seconds (wire), completed_at (wire for finished jobs), command, unique_name, source_name, args, cwd, file_path
 - Background monitoring task updates job state on child exit
@@ -507,7 +509,7 @@ impl ServerHandler for DelaMcpServer {
 - **Deny by default**: Tasks not explicitly allowlisted are rejected with `NotAllowlisted` error
 - **Allowlist path**: Reads from `~/.config/dela/allowlist.toml` (same as CLI)
 - **Output limits**:
-  - Ring buffer: 1000 lines, 5MB max per job
+  - Ring buffer: 10,000 lines, 5MB max per job
   - Per-message chunk: 8KB max
 - **Concurrency**: Max 50 concurrent jobs (configurable), rejects beyond limit
 - **Path policy**: Tasks execute with `cwd` under server root (no upward traversal)

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -287,8 +287,8 @@ Implement the minimal surface so editors can start using MCP immediately for dis
 - [x] **[DTKT-162]** Implement `list_tasks` enrichment: compute command, test runner availability, and allowlist flag
 - [x] **[DTKT-163]** Implement **task_start (quick)**:
   - Spawn the task, capture stdout/stderr up to **1s**
-  - If exits ≤1s → return `{ state: "exited", exit_code, initial_output }`
-  - If still running → return `{ state: "running", pid, initial_output }` **but do not persist/manage background yet** (documented limitation)
+  - If exits ≤1s → return `{ state: "exited", exit_code, output }`
+  - If still running → return `{ state: "running", pid, output }` **but do not persist/manage background yet** (documented limitation)
 - [x] **[DTKT-164]** Implement **status** that returns an **empty array** in Quick phase (documented that background processes are unsupported yet)
 - [x] **[DTKT-165]** Error taxonomy for **NotAllowlisted**, **RunnerUnavailable**, **TaskNotFound**
 - [x] **[DTKT-166]** Unit tests for `list_tasks` enrichment and `task_start` quick path
@@ -323,6 +323,7 @@ Advanced MCP features for better editor integration and real-time feedback.
 
 **High Priority:**
 - [x] **[DTKT-177]** MCP **logging notifications** for real-time output streaming (tracing + subscriber)
+- [x] **[DTKT-201]** Add stream-aware `task_start` output chunks for both `output` and `initial_output`
 - [x] **[DTKT-186]** **Editor config generation** - generate `.cursor/mcp.json` or similar config files via `dela mcp --init-cursor`
 
 **Medium Priority:**

--- a/dev_docs/project_plan.md
+++ b/dev_docs/project_plan.md
@@ -308,6 +308,7 @@ Add PID management, output buffers, and controls.
 - [x] **[DTKT-172]** Complete `status` to list **all running PIDs** with minimal info
 - [x] **[DTKT-173]** Implement `task_status` (filter by unique_name, return many PIDs)
 - [x] **[DTKT-174]** Implement `task_output` **tail last N lines** (default 200); add truncation flag
+- [x] **[DTKT-202]** Add stream-aware `task_output.output` chunks and remove superseded `lines` responses
 - [x] **[DTKT-175]** Implement `task_stop` with **TERM + grace + KILL**
 - [x] **[DTKT-176]** Concurrency and safety limits (max concurrent jobs, per-message chunk cap)
 - [x] **[DTKT-179]** Integration tests for long-running jobs: start → status → output → stop
@@ -323,7 +324,7 @@ Advanced MCP features for better editor integration and real-time feedback.
 
 **High Priority:**
 - [x] **[DTKT-177]** MCP **logging notifications** for real-time output streaming (tracing + subscriber)
-- [x] **[DTKT-201]** Add stream-aware `task_start` output chunks for both `output` and `initial_output`
+- [x] **[DTKT-201]** Add stream-aware `task_start.output` chunks
 - [x] **[DTKT-186]** **Editor config generation** - generate `.cursor/mcp.json` or similar config files via `dela mcp --init-cursor`
 
 **Medium Priority:**
@@ -333,11 +334,11 @@ Advanced MCP features for better editor integration and real-time feedback.
 - [ ] **[DTKT-192]** **Robust editor config generation** - support JSONC-aware merges, optionally write absolute `dela` binary paths for GUI editor MCP configs, and add workspace-aware `cwd` generation modes
 - [x] **[DTKT-193]** **Bounded wait execution** - `task_start` now accepts `wait_for_exit_seconds`, extending the default 1-second wait window for short/medium tasks like tests and builds before falling back to background execution
 - [x] **[DTKT-194]** **Completion metadata in task_status** - `task_status` now includes `exit_code` for exited jobs and `completed_at` for exited/failed jobs so clients do not need to infer outcomes from notifications
-- [ ] **[DTKT-195]** **Cursor-based log paging** - support `task_output(from=...)` or equivalent incremental log fetches
+- [x] **[DTKT-195]** **Output window paging** - support `task_output(offset=..., lines=...)` incremental log fetches over the retained buffer
 - [ ] **[DTKT-196]** **MCP smoke test CLI** - provide `dela mcp --self-test` and/or `dela mcp --inspect-task <task>` for local MCP debugging without hand-written JSON-RPC
 
 **Lower Priority:**
-- [ ] **[DTKT-178]** MCP **Resources** `job://<pid>` for job state snapshots, `joblog://<pid>?from=…` for log paging
+- [ ] **[DTKT-178]** MCP **Resources** `job://<pid>` for job state snapshots, `joblog://<pid>?offset=...` for log paging
 - [ ] **[DTKT-181]** Task **stdin support** - allow sending input to running tasks via MCP
 - [ ] **[DTKT-184]** **Prompts** - implement MCP prompts for common workflows (e.g., "run tests", "build project")
 - [ ] **[DTKT-185]** **Sampling** - support MCP sampling for AI-assisted task selection

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -622,6 +622,34 @@ pub struct TaskStartArgs {
     pub wait_for_exit_seconds: Option<u64>,
 }
 
+/// One chunk of task output from a single stream.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct OutputChunkDto {
+    /// Stdout text captured for this chunk
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+
+    /// Stderr text captured for this chunk
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+}
+
+impl OutputChunkDto {
+    pub fn stdout(text: String) -> Self {
+        Self {
+            stdout: Some(text),
+            stderr: None,
+        }
+    }
+
+    pub fn stderr(text: String) -> Self {
+        Self {
+            stdout: None,
+            stderr: Some(text),
+        }
+    }
+}
+
 /// Result of starting a task
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct StartResultDto {
@@ -636,8 +664,11 @@ pub struct StartResultDto {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
 
-    /// Combined stdout and stderr captured before returning
-    pub initial_output: String,
+    /// Output chunks captured before returning, preserving stream identity.
+    pub output: Vec<OutputChunkDto>,
+
+    /// Initial output chunks captured before returning, preserving stream identity.
+    pub initial_output: Vec<OutputChunkDto>,
 }
 
 /// Arguments for the task_status tool

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -666,9 +666,6 @@ pub struct StartResultDto {
 
     /// Output chunks captured before returning, preserving stream identity.
     pub output: Vec<OutputChunkDto>,
-
-    /// Initial output chunks captured before returning, preserving stream identity.
-    pub initial_output: Vec<OutputChunkDto>,
 }
 
 /// Arguments for the task_status tool
@@ -687,6 +684,11 @@ pub struct TaskOutputArgs {
     /// Number of lines to return (default: 200)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lines: Option<usize>,
+
+    /// Zero-based offset into the currently retained output buffer.
+    /// If omitted, returns the last `lines` entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
 
     /// Whether the output was truncated due to buffer limits
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -39,10 +39,30 @@ pub struct JobMetadata {
     pub file_path: PathBuf,
 }
 
+/// A single captured output line with its source stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputLine {
+    pub stream: String,
+    pub text: String,
+}
+
+impl OutputLine {
+    pub fn new(stream: impl Into<String>, text: impl Into<String>) -> Self {
+        Self {
+            stream: stream.into(),
+            text: text.into(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.text.len()
+    }
+}
+
 /// Ring buffer for storing job output
 #[derive(Debug, Clone)]
 pub struct RingBuffer {
-    buffer: VecDeque<String>,
+    buffer: VecDeque<OutputLine>,
     max_size: usize,
     total_bytes: usize,
     max_bytes: usize,
@@ -60,8 +80,9 @@ impl RingBuffer {
     }
 
     /// Add a line to the buffer, maintaining size limits
-    pub fn push_line(&mut self, line: String) {
-        let line_bytes = line.len();
+    pub fn push_line(&mut self, stream: impl Into<String>, line: String) {
+        let entry = OutputLine::new(stream, line);
+        let line_bytes = entry.len();
 
         // Remove lines from the front if we exceed the line limit
         while self.buffer.len() >= self.max_size {
@@ -79,13 +100,14 @@ impl RingBuffer {
 
         // Add the new line if we have space
         if self.total_bytes + line_bytes <= self.max_bytes {
-            self.buffer.push_back(line);
+            self.buffer.push_back(entry);
             self.total_bytes += line_bytes;
         }
     }
 
-    /// Get the last N lines from the buffer
-    pub fn get_last_lines(&self, n: usize) -> Vec<String> {
+    /// Get the last N entries from the buffer
+    #[cfg(test)]
+    pub fn get_last_entries(&self, n: usize) -> Vec<OutputLine> {
         let start = if self.buffer.len() > n {
             self.buffer.len() - n
         } else {
@@ -95,9 +117,38 @@ impl RingBuffer {
         self.buffer.iter().skip(start).cloned().collect()
     }
 
-    /// Get all lines in the buffer
-    pub fn get_all_lines(&self) -> Vec<String> {
+    /// Get all entries in the buffer
+    #[cfg(test)]
+    pub fn get_all_entries(&self) -> Vec<OutputLine> {
         self.buffer.iter().cloned().collect()
+    }
+
+    /// Get entries from a zero-based offset into the retained buffer.
+    pub fn get_entries_from(&self, offset: usize, count: usize) -> Vec<OutputLine> {
+        self.buffer
+            .iter()
+            .skip(offset)
+            .take(count)
+            .cloned()
+            .collect()
+    }
+
+    /// Get the last N lines from the buffer
+    #[cfg(test)]
+    pub fn get_last_lines(&self, n: usize) -> Vec<String> {
+        self.get_last_entries(n)
+            .into_iter()
+            .map(|entry| entry.text)
+            .collect()
+    }
+
+    /// Get all lines in the buffer
+    #[cfg(test)]
+    pub fn get_all_lines(&self) -> Vec<String> {
+        self.get_all_entries()
+            .into_iter()
+            .map(|entry| entry.text)
+            .collect()
     }
 
     /// Get the total number of lines stored
@@ -180,15 +231,21 @@ impl Job {
     }
 
     /// Add output to the job's ring buffer
-    pub fn add_output(&mut self, output: String) {
+    pub fn add_output(&mut self, stream: &str, output: String) {
         // Split output into lines and add each line
         for line in output.lines() {
-            self.output_buffer.push_line(line.to_string());
+            self.output_buffer.push_line(stream, line.to_string());
         }
         self.touch();
     }
 
+    /// Get the job's output as stream-tagged lines from a retained-buffer offset.
+    pub fn get_output_entries_from(&self, offset: usize, count: usize) -> Vec<OutputLine> {
+        self.output_buffer.get_entries_from(offset, count)
+    }
+
     /// Get the job's output as lines
+    #[cfg(test)]
     pub fn get_output_lines(&self, max_lines: Option<usize>) -> Vec<String> {
         match max_lines {
             Some(n) => self.output_buffer.get_last_lines(n),
@@ -231,7 +288,7 @@ impl Default for JobManagerConfig {
     fn default() -> Self {
         Self {
             max_concurrent_jobs: 50,
-            max_output_lines_per_job: 1000,
+            max_output_lines_per_job: 10_000,
             max_output_bytes_per_job: 5 * 1024 * 1024, // 5MB
             job_ttl_seconds: 3600,                     // 1 hour
             gc_interval_seconds: 300,                  // 5 minutes
@@ -400,11 +457,22 @@ impl JobManager {
         }
     }
 
-    /// Add output to a job
+    /// Add stdout output to a job for tests that do not care about stream identity.
+    #[cfg(test)]
     pub async fn add_job_output(&self, pid: u32, output: String) -> anyhow::Result<()> {
+        self.add_job_output_chunk(pid, "stdout", output).await
+    }
+
+    /// Add stream-tagged output to a job.
+    pub async fn add_job_output_chunk(
+        &self,
+        pid: u32,
+        stream: &str,
+        output: String,
+    ) -> anyhow::Result<()> {
         let mut jobs = self.jobs.write().await;
         if let Some(job) = jobs.get_mut(&pid) {
-            job.add_output(output);
+            job.add_output(stream, output);
             Ok(())
         } else {
             Err(anyhow::anyhow!("Job with PID {} not found", pid))
@@ -724,21 +792,22 @@ mod tests {
     fn test_ring_buffer_basic() {
         let mut buffer = RingBuffer::new(3, 100);
 
-        buffer.push_line("line1".to_string());
-        buffer.push_line("line2".to_string());
-        buffer.push_line("line3".to_string());
+        buffer.push_line("stdout", "line1".to_string());
+        buffer.push_line("stderr", "line2".to_string());
+        buffer.push_line("stdout", "line3".to_string());
 
         assert_eq!(buffer.len(), 3);
         assert_eq!(buffer.get_all_lines(), vec!["line1", "line2", "line3"]);
+        assert_eq!(buffer.get_all_entries()[1].stream, "stderr");
     }
 
     #[test]
     fn test_ring_buffer_overflow() {
         let mut buffer = RingBuffer::new(2, 100);
 
-        buffer.push_line("line1".to_string());
-        buffer.push_line("line2".to_string());
-        buffer.push_line("line3".to_string());
+        buffer.push_line("stdout", "line1".to_string());
+        buffer.push_line("stdout", "line2".to_string());
+        buffer.push_line("stdout", "line3".to_string());
 
         assert_eq!(buffer.len(), 2);
         assert_eq!(buffer.get_all_lines(), vec!["line2", "line3"]);
@@ -749,7 +818,7 @@ mod tests {
         let mut buffer = RingBuffer::new(5, 100);
 
         for i in 1..=5 {
-            buffer.push_line(format!("line{}", i));
+            buffer.push_line("stdout", format!("line{}", i));
         }
 
         assert_eq!(buffer.get_last_lines(2), vec!["line4", "line5"]);

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4,7 +4,7 @@ use super::dto::{
     TaskStatusArgs, TaskStopArgs,
 };
 use super::errors::DelaError;
-use super::job_manager::{JobManager, JobMetadata, JobState};
+use super::job_manager::{JobManager, JobMetadata, JobState, OutputLine};
 use crate::runner::{is_runner_available_for_mcp, split_command_words};
 use crate::task_discovery;
 use chrono::SecondsFormat;
@@ -210,34 +210,41 @@ impl DelaMcpServer {
         }
     }
 
-    fn append_initial_output(
-        output: &mut String,
-        chunks: &mut Vec<OutputChunkDto>,
-        stream: &str,
-        line: &str,
-    ) {
-        match stream {
-            "stderr" => {
-                if !output.contains("STDERR:") {
-                    if !output.is_empty() {
-                        output.push('\n');
-                    }
-                    output.push_str("STDERR:\n");
-                }
-            }
-            _ => {
-                if output.is_empty() {
-                    output.push_str("STDOUT:\n");
-                }
-            }
-        }
-
-        output.push_str(line);
-
+    fn append_output_chunk(chunks: &mut Vec<OutputChunkDto>, stream: &str, line: &str) {
         match stream {
             "stderr" => chunks.push(OutputChunkDto::stderr(line.to_string())),
             _ => chunks.push(OutputChunkDto::stdout(line.to_string())),
         }
+    }
+
+    async fn add_job_output_chunks(
+        job_manager: &JobManager,
+        pid: u32,
+        chunks: &[OutputChunkDto],
+    ) -> anyhow::Result<()> {
+        for chunk in chunks {
+            if let Some(text) = &chunk.stdout {
+                job_manager
+                    .add_job_output_chunk(pid, "stdout", text.clone())
+                    .await?;
+            }
+            if let Some(text) = &chunk.stderr {
+                job_manager
+                    .add_job_output_chunk(pid, "stderr", text.clone())
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    fn output_entries_to_json(entries: &[OutputLine]) -> Vec<serde_json::Value> {
+        entries
+            .iter()
+            .map(|entry| match entry.stream.as_str() {
+                "stderr" => serde_json::json!({ "stderr": entry.text }),
+                _ => serde_json::json!({ "stdout": entry.text }),
+            })
+            .collect()
     }
 
     async fn flush_output_notification_batch(
@@ -547,8 +554,7 @@ impl DelaMcpServer {
         let capture_duration = Duration::from_secs(Self::resolve_wait_for_exit_seconds(
             args.wait_for_exit_seconds,
         )?);
-        let initial_output = Arc::new(tokio::sync::Mutex::new(String::new()));
-        let initial_output_chunks = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let captured_output_chunks = Arc::new(tokio::sync::Mutex::new(Vec::new()));
         let peer_clone = self.peer.clone();
 
         // Create channels for output streaming
@@ -600,8 +606,7 @@ impl DelaMcpServer {
         };
 
         // Collect initial output for ~1 second while also streaming to logging
-        let initial_output_clone = initial_output.clone();
-        let initial_output_chunks_clone = initial_output_chunks.clone();
+        let captured_output_chunks_clone = captured_output_chunks.clone();
         let peer_for_initial = peer_clone.clone();
         let pid_u32 = pid as u32;
 
@@ -635,14 +640,8 @@ impl DelaMcpServer {
                         match line {
                             Some(line) => {
                                 {
-                                    let mut output = initial_output_clone.lock().await;
-                                    let mut chunks = initial_output_chunks_clone.lock().await;
-                                    DelaMcpServer::append_initial_output(
-                                        &mut output,
-                                        &mut chunks,
-                                        "stdout",
-                                        &line,
-                                    );
+                                    let mut chunks = captured_output_chunks_clone.lock().await;
+                                    DelaMcpServer::append_output_chunk(&mut chunks, "stdout", &line);
                                 }
                                 stdout_batch.add_line(&line);
                                 if stdout_batch.should_flush() {
@@ -669,14 +668,8 @@ impl DelaMcpServer {
                         match line {
                             Some(line) => {
                                 {
-                                    let mut output = initial_output_clone.lock().await;
-                                    let mut chunks = initial_output_chunks_clone.lock().await;
-                                    DelaMcpServer::append_initial_output(
-                                        &mut output,
-                                        &mut chunks,
-                                        "stderr",
-                                        &line,
-                                    );
+                                    let mut chunks = captured_output_chunks_clone.lock().await;
+                                    DelaMcpServer::append_output_chunk(&mut chunks, "stderr", &line);
                                 }
                                 stderr_batch.add_line(&line);
                                 if stderr_batch.should_flush() {
@@ -779,8 +772,7 @@ impl DelaMcpServer {
             })?;
 
             let exit_code = exit_status.code();
-            let output = initial_output.lock().await.clone();
-            let output_chunks = initial_output_chunks.lock().await.clone();
+            let output_chunks = captured_output_chunks.lock().await.clone();
 
             // Wait for reader tasks to finish
             if let Some(task) = stdout_task {
@@ -814,10 +806,8 @@ impl DelaMcpServer {
                 })?;
 
             // Add output to the job record
-            if !output.is_empty() {
-                let _ = self
-                    .job_manager
-                    .add_job_output(pid as u32, output.clone())
+            if !output_chunks.is_empty() {
+                let _ = Self::add_job_output_chunks(&self.job_manager, pid as u32, &output_chunks)
                     .await;
             }
 
@@ -836,8 +826,7 @@ impl DelaMcpServer {
                 state: "exited".to_string(),
                 pid: None,
                 exit_code,
-                output: output_chunks.clone(),
-                initial_output: output_chunks,
+                output: output_chunks,
             };
 
             return Ok(CallToolResult::success(vec![
@@ -846,8 +835,7 @@ impl DelaMcpServer {
         }
 
         // Process is still running - set up background monitoring
-        let output = initial_output.lock().await.clone();
-        let output_chunks = initial_output_chunks.lock().await.clone();
+        let output_chunks = captured_output_chunks.lock().await.clone();
 
         // Create job metadata
         let metadata = JobMetadata {
@@ -873,9 +861,8 @@ impl DelaMcpServer {
             })?;
 
         // Add initial output to the job
-        if !output.is_empty() {
-            self.job_manager
-                .add_job_output(pid as u32, output.clone())
+        if !output_chunks.is_empty() {
+            Self::add_job_output_chunks(&self.job_manager, pid as u32, &output_chunks)
                 .await
                 .map_err(|e| {
                     DelaError::internal_error(
@@ -917,7 +904,9 @@ impl DelaMcpServer {
                     }, if !stdout_done => {
                         match line {
                             Some(line) => {
-                                let _ = job_manager.add_job_output(pid_u32, line.clone()).await;
+                                let _ = job_manager
+                                    .add_job_output_chunk(pid_u32, "stdout", line.clone())
+                                    .await;
                                 stdout_batch.add_line(&line);
                                 if stdout_batch.should_flush() {
                                     DelaMcpServer::flush_output_notification_batch(
@@ -948,7 +937,9 @@ impl DelaMcpServer {
                     }, if !stderr_done => {
                         match line {
                             Some(line) => {
-                                let _ = job_manager.add_job_output(pid_u32, line.clone()).await;
+                                let _ = job_manager
+                                    .add_job_output_chunk(pid_u32, "stderr", line.clone())
+                                    .await;
                                 stderr_batch.add_line(&line);
                                 if stderr_batch.should_flush() {
                                     DelaMcpServer::flush_output_notification_batch(
@@ -1049,8 +1040,7 @@ impl DelaMcpServer {
             state: "running".to_string(),
             pid: Some(pid),
             exit_code: None,
-            output: output_chunks.clone(),
-            initial_output: output_chunks,
+            output: output_chunks,
         };
 
         Ok(CallToolResult::success(vec![
@@ -1101,7 +1091,7 @@ impl DelaMcpServer {
         ]))
     }
 
-    #[tool(description = "Tail last N lines for a PID")]
+    #[tool(description = "Read output chunks for a PID")]
     pub async fn task_output(
         &self,
         Parameters(args): Parameters<TaskOutputArgs>,
@@ -1113,19 +1103,27 @@ impl DelaMcpServer {
             .ok_or_else(|| DelaError::task_not_found(format!("Job with PID {}", args.pid)))?;
 
         let requested_lines = args.lines.unwrap_or(200);
-        let lines = job.get_output_lines(Some(requested_lines));
         let total_lines = job.output_buffer.len();
+        let offset = args
+            .offset
+            .unwrap_or_else(|| total_lines.saturating_sub(requested_lines))
+            .min(total_lines);
+        let output_entries = job.get_output_entries_from(offset, requested_lines);
+        let returned_lines = output_entries.len();
+        let next_offset = offset + returned_lines;
+        let output = Self::output_entries_to_json(&output_entries);
         let total_bytes = job.output_buffer.total_bytes();
 
-        // Check if output was truncated
-        let is_truncated = total_lines > requested_lines;
         let buffer_full = job.output_buffer.is_full();
+        let is_truncated = offset > 0 || next_offset < total_lines || buffer_full;
 
         // Apply per-message chunk size limit (8KB default)
         const MAX_CHUNK_SIZE: usize = 8 * 1024; // 8KB
         let mut response = serde_json::json!({
             "pid": job.pid,
-            "lines": lines,
+            "output": output,
+            "offset": offset,
+            "next_offset": next_offset,
             "total_lines": total_lines,
             "total_bytes": total_bytes,
             "truncated": is_truncated,
@@ -1136,7 +1134,7 @@ impl DelaMcpServer {
         if args.show_truncation.unwrap_or(false) {
             response["truncation_info"] = serde_json::json!({
                 "requested_lines": requested_lines,
-                "returned_lines": lines.len(),
+                "returned_lines": returned_lines,
                 "is_truncated": is_truncated,
                 "buffer_full": buffer_full,
                 "buffer_capacity": job.output_buffer.capacity()
@@ -1147,45 +1145,52 @@ impl DelaMcpServer {
         let response_json = serde_json::to_string(&response).unwrap_or_default();
         if response_json.len() > MAX_CHUNK_SIZE {
             // Truncate the response to fit within chunk size limit
-            let truncated_lines = if lines.len() > 1 {
+            let truncated_entries = if output_entries.len() > 1 {
                 // Try to fit as many lines as possible within the limit
-                let mut truncated_lines = Vec::new();
+                let mut truncated_entries = Vec::new();
                 let mut current_size = 0;
 
-                for line in &lines {
-                    let line_json = serde_json::to_string(line).unwrap_or_default();
-                    if current_size + line_json.len() + 100 < MAX_CHUNK_SIZE {
+                for entry in &output_entries {
+                    let entry_json = serde_json::to_string(
+                        &Self::output_entries_to_json(std::slice::from_ref(entry))[0],
+                    )
+                    .unwrap_or_default();
+                    if current_size + entry_json.len() + 100 < MAX_CHUNK_SIZE {
                         // 100 bytes buffer for JSON structure
-                        truncated_lines.push(line.clone());
-                        current_size += line_json.len();
+                        truncated_entries.push(entry.clone());
+                        current_size += entry_json.len();
                     } else {
                         break;
                     }
                 }
 
-                if truncated_lines.is_empty() && !lines.is_empty() {
+                if truncated_entries.is_empty() && !output_entries.is_empty() {
                     // If even one line is too big, truncate it
-                    let first_line = &lines[0];
-                    let mut truncated_line = first_line.clone();
+                    let first_entry = &output_entries[0];
+                    let mut truncated_line = first_entry.text.clone();
                     if truncated_line.len() > MAX_CHUNK_SIZE - 200 {
                         // 200 bytes buffer
                         truncated_line.truncate(MAX_CHUNK_SIZE - 200);
                         truncated_line.push_str("... [truncated]");
                     }
-                    truncated_lines.push(truncated_line);
+                    truncated_entries
+                        .push(OutputLine::new(first_entry.stream.clone(), truncated_line));
                 }
 
-                truncated_lines
+                truncated_entries
             } else {
-                lines
+                output_entries
             };
 
-            response["lines"] = serde_json::Value::Array(
-                truncated_lines
-                    .into_iter()
-                    .map(serde_json::Value::String)
-                    .collect(),
-            );
+            response["output"] =
+                serde_json::Value::Array(Self::output_entries_to_json(&truncated_entries));
+            response["next_offset"] = serde_json::Value::Number(serde_json::Number::from(
+                offset + truncated_entries.len(),
+            ));
+            if args.show_truncation.unwrap_or(false) {
+                response["truncation_info"]["returned_lines"] =
+                    serde_json::Value::Number(serde_json::Number::from(truncated_entries.len()));
+            }
             response["chunk_truncated"] = serde_json::Value::Bool(true);
             response["max_chunk_size"] =
                 serde_json::Value::Number(serde_json::Number::from(MAX_CHUNK_SIZE));
@@ -1587,6 +1592,22 @@ impl ServerHandler for DelaMcpServer {
             "lines".to_string(),
             serde_json::Value::Object(task_output_lines_prop),
         );
+        let mut task_output_offset_prop = Map::new();
+        task_output_offset_prop.insert(
+            "type".to_string(),
+            serde_json::Value::String("integer".to_string()),
+        );
+        task_output_offset_prop.insert(
+            "description".to_string(),
+            serde_json::Value::String(
+                "Zero-based offset into the currently retained output buffer. If omitted, returns the tail."
+                    .to_string(),
+            ),
+        );
+        task_output_properties.insert(
+            "offset".to_string(),
+            serde_json::Value::Object(task_output_offset_prop),
+        );
         let mut task_output_truncation_prop = Map::new();
         task_output_truncation_prop.insert(
             "type".to_string(),
@@ -1749,6 +1770,7 @@ mod tests {
         let output_args = TaskOutputArgs {
             pid: 12345,
             lines: Some(10),
+            offset: None,
             show_truncation: None,
         };
         let stop_args = TaskStopArgs {
@@ -2135,10 +2157,16 @@ mod tests {
             .add_job_output(pid, "Line 1\nLine 2\nLine 3\n".to_string())
             .await
             .unwrap();
+        server
+            .job_manager
+            .add_job_output_chunk(pid, "stderr", "Warning 1\n".to_string())
+            .await
+            .unwrap();
 
         let args = TaskOutputArgs {
             pid,
             lines: Some(2),
+            offset: None,
             show_truncation: None,
         };
 
@@ -2153,11 +2181,17 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
                 let obj = json.as_object().unwrap();
                 assert_eq!(obj["pid"], pid);
-                assert!(obj["lines"].is_array());
-                assert_eq!(obj["total_lines"], 3);
+                assert!(!obj.contains_key("lines"));
+                assert!(obj["output"].is_array());
+                assert_eq!(obj["offset"], 2);
+                assert_eq!(obj["next_offset"], 4);
+                assert_eq!(obj["total_lines"], 4);
                 assert!(obj["total_bytes"].is_number());
-                assert_eq!(obj["truncated"], true); // We requested 2 lines but have 3
+                assert_eq!(obj["truncated"], true); // We requested 2 lines but have 4
                 assert!(obj["buffer_full"].is_boolean());
+                let output = obj["output"].as_array().unwrap();
+                assert_eq!(output.len(), 2);
+                assert_eq!(output[1]["stderr"], "Warning 1");
             }
             _ => panic!("Expected text content with JSON"),
         }
@@ -2205,6 +2239,7 @@ mod tests {
         let args = TaskOutputArgs {
             pid,
             lines: Some(3),
+            offset: None,
             show_truncation: Some(true),
         };
 
@@ -2219,7 +2254,10 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
                 let obj = json.as_object().unwrap();
                 assert_eq!(obj["pid"], pid);
-                assert!(obj["lines"].is_array());
+                assert!(!obj.contains_key("lines"));
+                assert!(obj["output"].is_array());
+                assert_eq!(obj["offset"], 2);
+                assert_eq!(obj["next_offset"], 5);
                 assert_eq!(obj["total_lines"], 5);
                 assert_eq!(obj["truncated"], true);
 
@@ -2230,6 +2268,73 @@ mod tests {
                 assert_eq!(truncation_info["returned_lines"], 3);
                 assert_eq!(truncation_info["is_truncated"], true);
                 assert!(truncation_info["buffer_capacity"].is_number());
+            }
+            _ => panic!("Expected text content with JSON"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_task_output_with_offset_window() {
+        // Arrange
+        let temp_dir = std::env::temp_dir();
+        let server = DelaMcpServer::new(temp_dir);
+
+        let metadata = JobMetadata {
+            started_at: std::time::Instant::now(),
+            unique_name: "test-task".to_string(),
+            source_name: "test".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            command: "echo test".to_string(),
+            file_path: PathBuf::from("Makefile"),
+        };
+
+        let mut cmd = tokio::process::Command::new("echo");
+        cmd.arg("test");
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        let child = cmd.spawn().unwrap();
+        let pid = child.id().unwrap();
+
+        server
+            .job_manager
+            .start_job(pid, metadata, child)
+            .await
+            .unwrap();
+
+        server
+            .job_manager
+            .add_job_output(pid, "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n".to_string())
+            .await
+            .unwrap();
+
+        let args = TaskOutputArgs {
+            pid,
+            lines: Some(2),
+            offset: Some(1),
+            show_truncation: Some(true),
+        };
+
+        // Act
+        let result = server.task_output(Parameters(args)).await.unwrap();
+
+        // Assert
+        let content = &result.content[0];
+        match &content.raw {
+            RawContent::Text(text_content) => {
+                let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
+                let obj = json.as_object().unwrap();
+                let output = obj["output"].as_array().unwrap();
+                assert!(!obj.contains_key("lines"));
+                assert_eq!(output.len(), 2);
+                assert_eq!(output[0]["stdout"], "Line 2");
+                assert_eq!(output[1]["stdout"], "Line 3");
+                assert_eq!(obj["offset"], 1);
+                assert_eq!(obj["next_offset"], 3);
+                assert_eq!(obj["total_lines"], 5);
+                assert_eq!(obj["truncated"], true);
+                assert_eq!(obj["truncation_info"]["returned_lines"], 2);
             }
             _ => panic!("Expected text content with JSON"),
         }
@@ -2277,6 +2382,7 @@ mod tests {
         let args = TaskOutputArgs {
             pid,
             lines: Some(5), // Request more lines than available
+            offset: None,
             show_truncation: Some(true),
         };
 
@@ -2291,7 +2397,10 @@ mod tests {
                 let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
                 let obj = json.as_object().unwrap();
                 assert_eq!(obj["pid"], pid);
-                assert!(obj["lines"].is_array());
+                assert!(!obj.contains_key("lines"));
+                assert!(obj["output"].is_array());
+                assert_eq!(obj["offset"], 0);
+                assert_eq!(obj["next_offset"], 2);
                 assert_eq!(obj["total_lines"], 2);
                 assert_eq!(obj["truncated"], false); // No truncation since we have fewer lines than requested
 
@@ -2315,6 +2424,7 @@ mod tests {
         let args = TaskOutputArgs {
             pid: 99999, // Non-existent PID
             lines: Some(10),
+            offset: None,
             show_truncation: None,
         };
 
@@ -2507,7 +2617,7 @@ mod tests {
         // Create a job manager with very low concurrency limit for testing
         let config = crate::mcp::job_manager::JobManagerConfig {
             max_concurrent_jobs: 2,
-            max_output_lines_per_job: 1000,
+            max_output_lines_per_job: 10_000,
             max_output_bytes_per_job: 5 * 1024 * 1024,
             job_ttl_seconds: 3600,
             gc_interval_seconds: 300,
@@ -2616,6 +2726,7 @@ mod tests {
         let args = TaskOutputArgs {
             pid,
             lines: Some(1),
+            offset: None,
             show_truncation: Some(true),
         };
 
@@ -2636,11 +2747,10 @@ mod tests {
                 assert!(obj.contains_key("max_chunk_size"));
                 assert_eq!(obj["max_chunk_size"], 8192); // 8KB
 
-                // Lines should be present (may or may not be truncated depending on implementation)
-                let lines = obj["lines"].as_array().unwrap();
-                assert_eq!(lines.len(), 1);
-                let line = lines[0].as_str().unwrap();
-                // The line should exist and be reasonable in size
+                assert!(!obj.contains_key("lines"));
+                let output = obj["output"].as_array().unwrap();
+                assert_eq!(output.len(), 1);
+                let line = output[0]["stdout"].as_str().unwrap();
                 assert!(!line.is_empty());
                 // The chunk truncation should be indicated in the response
                 assert!(obj.contains_key("chunk_truncated"));
@@ -3424,7 +3534,7 @@ add_custom_target(build-all COMMENT "Build everything")
                 .and_then(|text| text.as_str())
                 .is_some_and(|text| text.contains("Warning on stderr"))
         }));
-        assert_eq!(json["initial_output"], json["output"]);
+        assert!(json.get("initial_output").is_none());
 
         let status_result = server.status().await.unwrap();
         let status_json = match &status_result.content[0].raw {
@@ -3527,7 +3637,7 @@ add_custom_target(build-all COMMENT "Build everything")
                 .and_then(|text| text.as_str())
                 .is_some_and(|text| text.contains("Starting..."))
         }));
-        assert_eq!(json["initial_output"], json["output"]);
+        assert!(json.get("initial_output").is_none());
 
         let status_result = server.status().await.unwrap();
         let status_json = match &status_result.content[0].raw {
@@ -3967,6 +4077,7 @@ add_custom_target(build-all COMMENT "Build everything")
         let out_args = TaskOutputArgs {
             pid,
             lines: Some(10),
+            offset: None,
             show_truncation: Some(true),
         };
         let out_result = server.task_output(Parameters(out_args)).await.unwrap();
@@ -3976,11 +4087,17 @@ add_custom_target(build-all COMMENT "Build everything")
                 let output_json: serde_json::Value =
                     serde_json::from_str(&text_content.text).unwrap();
                 assert_eq!(output_json["pid"].as_i64().unwrap() as u32, pid);
-                let lines = output_json["lines"].as_array().unwrap();
+                assert!(output_json.get("lines").is_none());
+                let output = output_json["output"].as_array().unwrap();
                 // Expect initial lines present
-                let joined = lines
+                let joined = output
                     .iter()
-                    .filter_map(|v| v.as_str())
+                    .filter_map(|chunk| {
+                        chunk
+                            .get("stdout")
+                            .or_else(|| chunk.get("stderr"))
+                            .and_then(|text| text.as_str())
+                    })
                     .collect::<Vec<_>>()
                     .join("\n");
                 assert!(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -21,7 +21,7 @@ use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, BufReader, stdin, stdout};
 use tokio::process::Command;
 use tokio::sync::{OnceCell, RwLock};
-use tokio::time::{Duration, timeout};
+use tokio::time::Duration;
 
 const TASK_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(60);
 const DEFAULT_TASK_START_WAIT_SECONDS: u64 = 1;
@@ -761,12 +761,7 @@ impl DelaMcpServer {
             (stdout_rx, stderr_rx)
         });
 
-        // Wait for initial capture with timeout
-        let capture_result = timeout(
-            capture_duration + Duration::from_millis(100),
-            initial_capture,
-        )
-        .await;
+        let capture_result = initial_capture.await;
 
         // Check if process exited during initial capture
         let process_exited = child.try_wait().is_ok_and(|status| status.is_some());
@@ -894,8 +889,7 @@ impl DelaMcpServer {
 
         tokio::spawn(async move {
             // Get the receivers from initial capture (if available)
-            let (mut stdout_rx_opt, mut stderr_rx_opt) = if let Ok(Ok((rx1, rx2))) = capture_result
-            {
+            let (mut stdout_rx_opt, mut stderr_rx_opt) = if let Ok((rx1, rx2)) = capture_result {
                 (Some(rx1), Some(rx2))
             } else {
                 (None, None)
@@ -1736,7 +1730,7 @@ impl ServerHandler for DelaMcpServer {
             ),
             Tool::new_with_raw(
                 "task_output",
-                Some("Tail last N lines for a PID".into()),
+                Some("Read stream-aware output chunks with optional offset paging".into()),
                 task_output_schema,
             ),
             Tool::new_with_raw(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,7 +1,7 @@
 use super::allowlist::McpAllowlistEvaluator;
 use super::dto::{
-    ListTasksArgs, StartResultDto, TaskDto, TaskOutputArgs, TaskStartArgs, TaskStatusArgs,
-    TaskStopArgs,
+    ListTasksArgs, OutputChunkDto, StartResultDto, TaskDto, TaskOutputArgs, TaskStartArgs,
+    TaskStatusArgs, TaskStopArgs,
 };
 use super::errors::DelaError;
 use super::job_manager::{JobManager, JobMetadata, JobState};
@@ -210,7 +210,12 @@ impl DelaMcpServer {
         }
     }
 
-    fn append_initial_output(output: &mut String, stream: &str, line: &str) {
+    fn append_initial_output(
+        output: &mut String,
+        chunks: &mut Vec<OutputChunkDto>,
+        stream: &str,
+        line: &str,
+    ) {
         match stream {
             "stderr" => {
                 if !output.contains("STDERR:") {
@@ -228,6 +233,11 @@ impl DelaMcpServer {
         }
 
         output.push_str(line);
+
+        match stream {
+            "stderr" => chunks.push(OutputChunkDto::stderr(line.to_string())),
+            _ => chunks.push(OutputChunkDto::stdout(line.to_string())),
+        }
     }
 
     async fn flush_output_notification_batch(
@@ -538,6 +548,7 @@ impl DelaMcpServer {
             args.wait_for_exit_seconds,
         )?);
         let initial_output = Arc::new(tokio::sync::Mutex::new(String::new()));
+        let initial_output_chunks = Arc::new(tokio::sync::Mutex::new(Vec::new()));
         let peer_clone = self.peer.clone();
 
         // Create channels for output streaming
@@ -590,6 +601,7 @@ impl DelaMcpServer {
 
         // Collect initial output for ~1 second while also streaming to logging
         let initial_output_clone = initial_output.clone();
+        let initial_output_chunks_clone = initial_output_chunks.clone();
         let peer_for_initial = peer_clone.clone();
         let pid_u32 = pid as u32;
 
@@ -624,7 +636,13 @@ impl DelaMcpServer {
                             Some(line) => {
                                 {
                                     let mut output = initial_output_clone.lock().await;
-                                    DelaMcpServer::append_initial_output(&mut output, "stdout", &line);
+                                    let mut chunks = initial_output_chunks_clone.lock().await;
+                                    DelaMcpServer::append_initial_output(
+                                        &mut output,
+                                        &mut chunks,
+                                        "stdout",
+                                        &line,
+                                    );
                                 }
                                 stdout_batch.add_line(&line);
                                 if stdout_batch.should_flush() {
@@ -652,7 +670,13 @@ impl DelaMcpServer {
                             Some(line) => {
                                 {
                                     let mut output = initial_output_clone.lock().await;
-                                    DelaMcpServer::append_initial_output(&mut output, "stderr", &line);
+                                    let mut chunks = initial_output_chunks_clone.lock().await;
+                                    DelaMcpServer::append_initial_output(
+                                        &mut output,
+                                        &mut chunks,
+                                        "stderr",
+                                        &line,
+                                    );
                                 }
                                 stderr_batch.add_line(&line);
                                 if stderr_batch.should_flush() {
@@ -756,6 +780,7 @@ impl DelaMcpServer {
 
             let exit_code = exit_status.code();
             let output = initial_output.lock().await.clone();
+            let output_chunks = initial_output_chunks.lock().await.clone();
 
             // Wait for reader tasks to finish
             if let Some(task) = stdout_task {
@@ -811,7 +836,8 @@ impl DelaMcpServer {
                 state: "exited".to_string(),
                 pid: None,
                 exit_code,
-                initial_output: output,
+                output: output_chunks.clone(),
+                initial_output: output_chunks,
             };
 
             return Ok(CallToolResult::success(vec![
@@ -821,6 +847,7 @@ impl DelaMcpServer {
 
         // Process is still running - set up background monitoring
         let output = initial_output.lock().await.clone();
+        let output_chunks = initial_output_chunks.lock().await.clone();
 
         // Create job metadata
         let metadata = JobMetadata {
@@ -1022,7 +1049,8 @@ impl DelaMcpServer {
             state: "running".to_string(),
             pid: Some(pid),
             exit_code: None,
-            initial_output: output,
+            output: output_chunks.clone(),
+            initial_output: output_chunks,
         };
 
         Ok(CallToolResult::success(vec![
@@ -3346,7 +3374,7 @@ add_custom_target(build-all COMMENT "Build everything")
         let script_path = temp_dir.path().join("waited_task.sh");
         std::fs::write(
             &script_path,
-            "#!/bin/bash\necho 'Starting...'\nsleep 2\necho 'Finished within wait window'\n",
+            "#!/bin/bash\necho 'Starting...'\necho 'Warning on stderr' >&2\nsleep 2\necho 'Finished within wait window'\n",
         )
         .unwrap();
         std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -3383,12 +3411,20 @@ add_custom_target(build-all COMMENT "Build everything")
         assert_eq!(json["state"], "exited");
         assert_eq!(json["exit_code"], 0);
         assert!(json.get("pid").is_none());
-        assert!(
-            json["initial_output"]
-                .as_str()
-                .unwrap()
-                .contains("Finished within wait window")
-        );
+        let output_chunks = json["output"].as_array().unwrap();
+        assert!(output_chunks.iter().any(|chunk| {
+            chunk
+                .get("stdout")
+                .and_then(|text| text.as_str())
+                .is_some_and(|text| text.contains("Finished within wait window"))
+        }));
+        assert!(output_chunks.iter().any(|chunk| {
+            chunk
+                .get("stderr")
+                .and_then(|text| text.as_str())
+                .is_some_and(|text| text.contains("Warning on stderr"))
+        }));
+        assert_eq!(json["initial_output"], json["output"]);
 
         let status_result = server.status().await.unwrap();
         let status_json = match &status_result.content[0].raw {
@@ -3484,12 +3520,14 @@ add_custom_target(build-all COMMENT "Build everything")
 
         assert_eq!(json["state"], "running");
         let pid = json["pid"].as_i64().unwrap() as u32;
-        assert!(
-            json["initial_output"]
-                .as_str()
-                .unwrap()
-                .contains("Starting...")
-        );
+        let output_chunks = json["output"].as_array().unwrap();
+        assert!(output_chunks.iter().any(|chunk| {
+            chunk
+                .get("stdout")
+                .and_then(|text| text.as_str())
+                .is_some_and(|text| text.contains("Starting..."))
+        }));
+        assert_eq!(json["initial_output"], json["output"]);
 
         let status_result = server.status().await.unwrap();
         let status_json = match &status_result.content[0].raw {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -247,6 +247,15 @@ impl DelaMcpServer {
             .collect()
     }
 
+    fn truncate_output_entry_for_chunk(entry: &OutputLine, max_chunk_size: usize) -> OutputLine {
+        let mut truncated_line = entry.text.clone();
+        if truncated_line.len() > max_chunk_size - 200 {
+            truncated_line.truncate(max_chunk_size - 200);
+            truncated_line.push_str("... [truncated]");
+        }
+        OutputLine::new(entry.stream.clone(), truncated_line)
+    }
+
     async fn flush_output_notification_batch(
         peer: &Arc<OnceCell<Peer<RoleServer>>>,
         pid: u32,
@@ -807,8 +816,14 @@ impl DelaMcpServer {
 
             // Add output to the job record
             if !output_chunks.is_empty() {
-                let _ = Self::add_job_output_chunks(&self.job_manager, pid as u32, &output_chunks)
-                    .await;
+                Self::add_job_output_chunks(&self.job_manager, pid as u32, &output_chunks)
+                    .await
+                    .map_err(|e| {
+                        DelaError::internal_error(
+                            format!("Failed to add completed task output: {}", e),
+                            Some("Job management error".to_string()),
+                        )
+                    })?;
             }
 
             // Send task completed event
@@ -904,9 +919,16 @@ impl DelaMcpServer {
                     }, if !stdout_done => {
                         match line {
                             Some(line) => {
-                                let _ = job_manager
+                                if let Err(error) = job_manager
                                     .add_job_output_chunk(pid_u32, "stdout", line.clone())
-                                    .await;
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        pid = pid_u32,
+                                        error = %error,
+                                        "failed to persist stdout output chunk"
+                                    );
+                                }
                                 stdout_batch.add_line(&line);
                                 if stdout_batch.should_flush() {
                                     DelaMcpServer::flush_output_notification_batch(
@@ -937,9 +959,16 @@ impl DelaMcpServer {
                     }, if !stderr_done => {
                         match line {
                             Some(line) => {
-                                let _ = job_manager
+                                if let Err(error) = job_manager
                                     .add_job_output_chunk(pid_u32, "stderr", line.clone())
-                                    .await;
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        pid = pid_u32,
+                                        error = %error,
+                                        "failed to persist stderr output chunk"
+                                    );
+                                }
                                 stderr_batch.add_line(&line);
                                 if stderr_batch.should_flush() {
                                     DelaMcpServer::flush_output_notification_batch(
@@ -1167,17 +1196,26 @@ impl DelaMcpServer {
                 if truncated_entries.is_empty() && !output_entries.is_empty() {
                     // If even one line is too big, truncate it
                     let first_entry = &output_entries[0];
-                    let mut truncated_line = first_entry.text.clone();
-                    if truncated_line.len() > MAX_CHUNK_SIZE - 200 {
-                        // 200 bytes buffer
-                        truncated_line.truncate(MAX_CHUNK_SIZE - 200);
-                        truncated_line.push_str("... [truncated]");
-                    }
-                    truncated_entries
-                        .push(OutputLine::new(first_entry.stream.clone(), truncated_line));
+                    truncated_entries.push(Self::truncate_output_entry_for_chunk(
+                        first_entry,
+                        MAX_CHUNK_SIZE,
+                    ));
                 }
 
                 truncated_entries
+            } else if let Some(first_entry) = output_entries.first() {
+                let entry_json = serde_json::to_string(
+                    &Self::output_entries_to_json(std::slice::from_ref(first_entry))[0],
+                )
+                .unwrap_or_default();
+                if entry_json.len() + 100 >= MAX_CHUNK_SIZE {
+                    vec![Self::truncate_output_entry_for_chunk(
+                        first_entry,
+                        MAX_CHUNK_SIZE,
+                    )]
+                } else {
+                    output_entries
+                }
             } else {
                 output_entries
             };
@@ -2752,6 +2790,8 @@ mod tests {
                 assert_eq!(output.len(), 1);
                 let line = output[0]["stdout"].as_str().unwrap();
                 assert!(!line.is_empty());
+                assert!(line.len() < 8192);
+                assert!(line.ends_with("... [truncated]"));
                 // The chunk truncation should be indicated in the response
                 assert!(obj.contains_key("chunk_truncated"));
             }

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -175,12 +175,13 @@ def output_text(payload, stream=None, field="output"):
     texts = []
     for chunk in chunks:
         assert_condition(isinstance(chunk, dict), "output chunk should be an object", payload)
-        assert_condition(len(chunk) == 1, "output chunk should have exactly one stream key", payload)
-        key, value = next(iter(chunk.items()))
-        assert_condition(key in {"stdout", "stderr"}, "output chunk has unknown stream key", payload)
-        assert_condition(isinstance(value, str), "output chunk value should be text", payload)
-        if stream is None or key == stream:
-            texts.append(value)
+        for key, value in chunk.items():
+            assert_condition(key in {"stdout", "stderr"}, "output chunk has unknown stream key", payload)
+            if value is None:
+                continue
+            assert_condition(isinstance(value, str), "output chunk value should be text", payload)
+            if stream is None or key == stream:
+                texts.append(value)
     return "".join(texts)
 
 

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -281,7 +281,7 @@ def test_task_start_quick_exit():
         assert_condition(payload["state"] == "exited", "quick task should exit", payload)
         assert_condition(payload.get("pid") is None, "quick exit should not report pid", payload)
         assert_condition(payload.get("exit_code") == 0, "quick exit should report exit_code 0", payload)
-        assert_condition(payload["initial_output"] == payload["output"], "initial_output should match output", payload)
+        assert_condition("initial_output" not in payload, "quick exit should not return initial_output", payload)
         assert_condition(
             "Test task executed successfully" in output_text(payload, "stdout"),
             "quick exit missing task output",
@@ -321,7 +321,7 @@ def test_task_start_args_and_spaces():
         payload = parse_tool_result(response)
         assert_condition(payload["state"] == "exited", "print-args should exit", payload)
         assert_condition(payload.get("exit_code") == 0, "print-args should exit successfully", payload)
-        assert_condition(payload["initial_output"] == payload["output"], "initial_output should match output", payload)
+        assert_condition("initial_output" not in payload, "print-args should not return initial_output", payload)
         output = output_text(payload)
         assert_condition("value with spaces" in output, "missing spaced arg in output", payload)
         print("✓ task_start preserves passed arguments")
@@ -379,7 +379,7 @@ def test_bounded_wait_completion():
         assert_condition(payload["state"] == "exited", "bounded wait should complete task", payload)
         assert_condition(payload.get("exit_code") == 0, "bounded wait should return exit_code 0", payload)
         assert_condition(payload.get("pid") is None, "bounded wait completion should not return pid", payload)
-        assert_condition(payload["initial_output"] == payload["output"], "initial_output should match output", payload)
+        assert_condition("initial_output" not in payload, "bounded wait should not return initial_output", payload)
         assert_condition(
             "Starting long-running task..." in output_text(payload, "stdout"),
             "missing initial stdout from bounded wait task",
@@ -441,11 +441,7 @@ def test_running_lifecycle_and_stop():
         assert_condition(start_payload["state"] == "running", "default start should background task", start_payload)
         pid = start_payload.get("pid")
         assert_condition(isinstance(pid, int) and pid > 0, "running task should expose pid", start_payload)
-        assert_condition(
-            start_payload["initial_output"] == start_payload["output"],
-            "initial_output should match output",
-            start_payload,
-        )
+        assert_condition("initial_output" not in start_payload, "running task should not return initial_output", start_payload)
         assert_condition(
             "Starting long-running task..." in output_text(start_payload, "stdout"),
             "running task missing initial output",
@@ -481,11 +477,33 @@ def test_running_lifecycle_and_stop():
         )
         output_payload = parse_tool_result(output_response)
         assert_condition(output_payload["pid"] == pid, "task_output pid mismatch", output_payload)
-        assert_condition(output_payload["lines"], "task_output should contain captured lines", output_payload)
+        assert_condition("lines" not in output_payload, "task_output should not return legacy lines", output_payload)
+        assert_condition(output_payload["output"], "task_output should contain captured output chunks", output_payload)
+        assert_condition(output_payload["offset"] >= 0, "task_output should report offset", output_payload)
+        assert_condition(output_payload["next_offset"] >= output_payload["offset"], "task_output should report next offset", output_payload)
+        assert_condition(
+            "Starting long-running task..." in output_text(output_payload, "stdout"),
+            "task_output should contain structured stdout chunks",
+            output_payload,
+        )
+
+        offset_response, _ = send_request(
+            process,
+            tool_request(15, "task_output", {"pid": pid, "offset": output_payload["offset"], "lines": 1}),
+        )
+        offset_payload = parse_tool_result(offset_response)
+        assert_condition("lines" not in offset_payload, "offset task_output should not return legacy lines", offset_payload)
+        assert_condition(len(offset_payload["output"]) == 1, "offset task_output should return requested chunk count", offset_payload)
+        assert_condition(offset_payload["offset"] == output_payload["offset"], "offset task_output should honor offset", offset_payload)
+        assert_condition(
+            offset_payload["next_offset"] == offset_payload["offset"] + 1,
+            "offset task_output should advance next_offset",
+            offset_payload,
+        )
 
         stop_response, _ = send_request(
             process,
-            tool_request(15, "task_stop", {"pid": pid, "grace_period": 2}),
+            tool_request(16, "task_stop", {"pid": pid, "grace_period": 2}),
             timeout_seconds=10,
         )
         stop_payload = parse_tool_result(stop_response)
@@ -496,7 +514,7 @@ def test_running_lifecycle_and_stop():
             stop_payload,
         )
 
-        status_after_stop, _ = send_request(process, tool_request(16, "status"))
+        status_after_stop, _ = send_request(process, tool_request(17, "status"))
         running_after_stop = parse_tool_result(status_after_stop)["running"]
         assert_condition(
             all(job.get("pid") != pid for job in running_after_stop),
@@ -515,13 +533,13 @@ def test_nonexistent_job_tools():
     try:
         output_response, _ = send_request(
             process,
-            tool_request(17, "task_output", {"pid": 99999, "lines": 10, "show_truncation": True}),
+            tool_request(18, "task_output", {"pid": 99999, "lines": 10, "show_truncation": True}),
         )
         assert_condition("error" in output_response, "task_output should error for bad pid", output_response)
 
         stop_response, _ = send_request(
             process,
-            tool_request(18, "task_stop", {"pid": 99999, "grace_period": 1}),
+            tool_request(19, "task_stop", {"pid": 99999, "grace_period": 1}),
         )
         assert_condition("error" in stop_response, "task_stop should error for bad pid", stop_response)
         print("✓ nonexistent-job tools return MCP errors")

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -481,7 +481,7 @@ def test_running_lifecycle_and_stop():
         assert_condition("lines" not in output_payload, "task_output should not return legacy lines", output_payload)
         assert_condition(output_payload["output"], "task_output should contain captured output chunks", output_payload)
         assert_condition(output_payload["offset"] >= 0, "task_output should report offset", output_payload)
-        assert_condition(output_payload["next_offset"] >= output_payload["offset"], "task_output should report next offset", output_payload)
+        assert_condition(output_payload["next_offset"] > output_payload["offset"], "task_output should advance next offset", output_payload)
         assert_condition(
             "Starting long-running task..." in output_text(output_payload, "stdout"),
             "task_output should contain structured stdout chunks",

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -168,6 +168,22 @@ def logging_notifications(notifications):
     return [n for n in notifications if n.get("method") == "notifications/message"]
 
 
+def output_text(payload, stream=None, field="output"):
+    chunks = payload.get(field)
+    assert_condition(isinstance(chunks, list), f"payload missing structured {field}", payload)
+
+    texts = []
+    for chunk in chunks:
+        assert_condition(isinstance(chunk, dict), "output chunk should be an object", payload)
+        assert_condition(len(chunk) == 1, "output chunk should have exactly one stream key", payload)
+        key, value = next(iter(chunk.items()))
+        assert_condition(key in {"stdout", "stderr"}, "output chunk has unknown stream key", payload)
+        assert_condition(isinstance(value, str), "output chunk value should be text", payload)
+        if stream is None or key == stream:
+            texts.append(value)
+    return "".join(texts)
+
+
 def test_initialize_instructions():
     print("Test 1: initialize advertises bounded wait and logging")
     process, init_response = start_mcp_process()
@@ -265,8 +281,9 @@ def test_task_start_quick_exit():
         assert_condition(payload["state"] == "exited", "quick task should exit", payload)
         assert_condition(payload.get("pid") is None, "quick exit should not report pid", payload)
         assert_condition(payload.get("exit_code") == 0, "quick exit should report exit_code 0", payload)
+        assert_condition(payload["initial_output"] == payload["output"], "initial_output should match output", payload)
         assert_condition(
-            "Test task executed successfully" in payload["initial_output"],
+            "Test task executed successfully" in output_text(payload, "stdout"),
             "quick exit missing task output",
             payload,
         )
@@ -304,7 +321,8 @@ def test_task_start_args_and_spaces():
         payload = parse_tool_result(response)
         assert_condition(payload["state"] == "exited", "print-args should exit", payload)
         assert_condition(payload.get("exit_code") == 0, "print-args should exit successfully", payload)
-        output = payload["initial_output"]
+        assert_condition(payload["initial_output"] == payload["output"], "initial_output should match output", payload)
+        output = output_text(payload)
         assert_condition("value with spaces" in output, "missing spaced arg in output", payload)
         print("✓ task_start preserves passed arguments")
         return True
@@ -361,13 +379,14 @@ def test_bounded_wait_completion():
         assert_condition(payload["state"] == "exited", "bounded wait should complete task", payload)
         assert_condition(payload.get("exit_code") == 0, "bounded wait should return exit_code 0", payload)
         assert_condition(payload.get("pid") is None, "bounded wait completion should not return pid", payload)
+        assert_condition(payload["initial_output"] == payload["output"], "initial_output should match output", payload)
         assert_condition(
-            "Starting long-running task..." in payload["initial_output"],
+            "Starting long-running task..." in output_text(payload, "stdout"),
             "missing initial stdout from bounded wait task",
             payload,
         )
         assert_condition(
-            "Long-running task completed successfully" in payload["initial_output"],
+            "Long-running task completed successfully" in output_text(payload, "stdout"),
             "missing completion stdout from bounded wait task",
             payload,
         )
@@ -423,7 +442,12 @@ def test_running_lifecycle_and_stop():
         pid = start_payload.get("pid")
         assert_condition(isinstance(pid, int) and pid > 0, "running task should expose pid", start_payload)
         assert_condition(
-            "Starting long-running task..." in start_payload["initial_output"],
+            start_payload["initial_output"] == start_payload["output"],
+            "initial_output should match output",
+            start_payload,
+        )
+        assert_condition(
+            "Starting long-running task..." in output_text(start_payload, "stdout"),
             "running task missing initial output",
             start_payload,
         )

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -177,8 +177,6 @@ def output_text(payload, stream=None, field="output"):
         assert_condition(isinstance(chunk, dict), "output chunk should be an object", payload)
         for key, value in chunk.items():
             assert_condition(key in {"stdout", "stderr"}, "output chunk has unknown stream key", payload)
-            if value is None:
-                continue
             assert_condition(isinstance(value, str), "output chunk value should be text", payload)
             if stream is None or key == stream:
                 texts.append(value)
@@ -556,7 +554,7 @@ def test_logging_severity_classification():
         response, notifications = send_request(
             process,
             tool_request(
-                19,
+                20,
                 "task_start",
                 {
                     "unique_name": "stderr-level-task",


### PR DESCRIPTION
## Summary

- Return stream-aware `output` chunks from `task_start` instead of `initial_output`.
- Return stream-aware `task_output` chunks with `offset`/`next_offset` pagination and no legacy `lines` field.
- Persist stdout/stderr separately in the job ring buffer and retain up to 10,000 entries.

## Validation

- `cargo fmt --all`
- `PYTHONPYCACHEPREFIX=/tmp/dela_pycache python3 -m py_compile tests/docker_mcp/test_mcp.py`
- `cargo test`
- `make lint`
- `make test_mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stream-aware output chunking with separate stdout and stderr tracking for enhanced task execution visibility
  * Offset-based pagination for improved task output retrieval and navigation

* **Improvements**
  * Significantly increased output buffer retention from 1,000 to 10,000 lines per task, enabling access to extended execution history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->