### PR TITLE
MCP support for additional agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ $ dela mcp --init-cursor       # Cursor: ~/.cursor/mcp.json
 $ dela mcp --init-vscode       # VSCode: ~/.vscode/mcp.json
 $ dela mcp --init-codex        # OpenAI Codex: ~/.codex/config.toml
 $ dela mcp --init-gemini       # Gemini CLI: ~/.gemini/settings.json
+$ dela mcp --init-antigravity  # Antigravity: ~/.gemini/antigravity-ide/mcp_config.json
 $ dela mcp --init-claude-code  # Claude Code: ~/.claude-code/settings.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Dela includes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/
 The mcp executed tasks need to be already on the allowlist. The mcp server respects the allowlist, but does not give agents tools to modify it. 
 
 ### Setting Up MCP for your agent
+
 You need to have dela installed first and then run the command for your coding agent.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Dela includes an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/
 
 The mcp executed tasks need to be already on the allowlist. The mcp server respects the allowlist, but does not give agents tools to modify it. 
 
-### Setting Up MCP in Your Editor
+### Setting Up MCP for your agent
+You need to have dela installed first and then run the command for your coding agent.
 
 ```sh
 $ dela mcp --init-cursor       # Cursor: ~/.cursor/mcp.json
@@ -80,6 +81,9 @@ $ dela mcp --init-codex        # OpenAI Codex: ~/.codex/config.toml
 $ dela mcp --init-gemini       # Gemini CLI: ~/.gemini/settings.json
 $ dela mcp --init-antigravity  # Antigravity: ~/.gemini/antigravity-ide/mcp_config.json
 $ dela mcp --init-claude-code  # Claude Code: ~/.claude-code/settings.json
+$ dela mcp --init-cline        # Cline: ~/.cline/data/settings/cline_mcp_settings.json (override with CLINE_MCP_SETTINGS_PATH)
+$ dela mcp --init-opencode     # OpenCode: ~/.config/opencode/opencode.json
+$ dela mcp --init-crush        # Crush: ~/.config/crush/crush.json
 ```
 
 ### Starting the MCP Server Manually

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -70,9 +70,9 @@
       "file": "./src/main.rs",
       "function": "run_command",
       "line": 198,
-      "cyclomatic": 20.0,
-      "coverage": 79.54545454545455,
-      "crap": 23.423178061607814
+      "cyclomatic": 21.0,
+      "coverage": 85.24590163934425,
+      "crap": 22.416369652085418
     },
     {
       "file": "./src/parsers/parse_pyproject_toml.rs",
@@ -141,7 +141,7 @@
     {
       "file": "./src/main.rs",
       "function": "main",
-      "line": 253,
+      "line": 271,
       "cyclomatic": 4.0,
       "coverage": 0.0,
       "crap": 20.0
@@ -223,8 +223,8 @@
       "function": "evaluate_task_against_allowlist",
       "line": 75,
       "cyclomatic": 17.0,
-      "coverage": 96.42857142857143,
-      "crap": 17.013165087463555
+      "coverage": 100.0,
+      "crap": 17.0
     },
     {
       "file": "./src/commands/allow_command.rs",

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -5,7 +5,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_job_graceful",
-      "line": 439,
+      "line": 507,
       "cyclomatic": 29.0,
       "coverage": 24.691358024691358,
       "crap": 388.19513360843445
@@ -13,7 +13,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::call_tool",
-      "line": 1265,
+      "line": 1330,
       "cyclomatic": 13.0,
       "coverage": 0.0,
       "crap": 182.0
@@ -27,14 +27,6 @@
       "crap": 182.0
     },
     {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::task_start",
-      "line": 414,
-      "cyclomatic": 43.0,
-      "coverage": 69.86899563318777,
-      "crap": 93.57987320997631
-    },
-    {
       "file": "./src/commands/list.rs",
       "function": "execute",
       "line": 22,
@@ -43,12 +35,12 @@
       "crap": 93.25000551433072
     },
     {
-      "file": "./src/main.rs",
-      "function": "run_command",
-      "line": 182,
-      "cyclomatic": 11.0,
-      "coverage": 20.689655172413794,
-      "crap": 71.36356554184265
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_start",
+      "line": 440,
+      "cyclomatic": 44.0,
+      "coverage": 71.12068965517241,
+      "crap": 90.6300419758908
     },
     {
       "file": "./src/prompt.rs",
@@ -59,17 +51,9 @@
       "crap": 57.54545454545455
     },
     {
-      "file": "./src/commands/mcp.rs",
-      "function": "execute",
-      "line": 243,
-      "cyclomatic": 19.0,
-      "coverage": 55.55555555555556,
-      "crap": 50.692729766803836
-    },
-    {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::garbage_collect",
-      "line": 633,
+      "line": 701,
       "cyclomatic": 8.0,
       "coverage": 22.22222222222222,
       "crap": 38.1124828532236
@@ -77,10 +61,18 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_job",
-      "line": 416,
+      "line": 484,
       "cyclomatic": 5.0,
       "coverage": 0.0,
       "crap": 30.0
+    },
+    {
+      "file": "./src/main.rs",
+      "function": "run_command",
+      "line": 198,
+      "cyclomatic": 20.0,
+      "coverage": 79.54545454545455,
+      "crap": 23.423178061607814
     },
     {
       "file": "./src/parsers/parse_pyproject_toml.rs",
@@ -149,7 +141,7 @@
     {
       "file": "./src/main.rs",
       "function": "main",
-      "line": 220,
+      "line": 253,
       "cyclomatic": 4.0,
       "coverage": 0.0,
       "crap": 20.0
@@ -179,12 +171,28 @@
       "crap": 19.038980671633734
     },
     {
+      "file": "./src/commands/mcp.rs",
+      "function": "generate_config_at",
+      "line": 167,
+      "cyclomatic": 19.0,
+      "coverage": 100.0,
+      "crap": 19.0
+    },
+    {
       "file": "./src/commands/init.rs",
       "function": "execute",
       "line": 100,
       "cyclomatic": 18.0,
       "coverage": 88.0,
       "crap": 18.559872
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_output",
+      "line": 1118,
+      "cyclomatic": 14.0,
+      "coverage": 73.25581395348837,
+      "crap": 17.74924849384331
     },
     {
       "file": "./src/allowlist.rs",
@@ -215,8 +223,8 @@
       "function": "evaluate_task_against_allowlist",
       "line": 75,
       "cyclomatic": 17.0,
-      "coverage": 100.0,
-      "crap": 17.0
+      "coverage": 96.42857142857143,
+      "crap": 17.013165087463555
     },
     {
       "file": "./src/commands/allow_command.rs",
@@ -243,20 +251,20 @@
       "crap": 16.041666666666664
     },
     {
+      "file": "./src/commands/mcp.rs",
+      "function": "execute",
+      "line": 248,
+      "cyclomatic": 6.0,
+      "coverage": 34.78260869565217,
+      "crap": 15.98602778006082
+    },
+    {
       "file": "./src/task_discovery/turbo.rs",
       "function": "resolve_effective_turbo_tasks",
       "line": 172,
       "cyclomatic": 15.0,
       "coverage": 92.3076923076923,
       "crap": 15.10241238051889
-    },
-    {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::task_output",
-      "line": 1077,
-      "cyclomatic": 10.0,
-      "coverage": 68.18181818181817,
-      "crap": 13.221262208865516
     },
     {
       "file": "./src/task_discovery/gradle.rs",
@@ -281,14 +289,6 @@
       "cyclomatic": 13.0,
       "coverage": 97.2972972972973,
       "crap": 13.003336426272876
-    },
-    {
-      "file": "./src/commands/mcp.rs",
-      "function": "generate_config_at",
-      "line": 171,
-      "cyclomatic": 13.0,
-      "coverage": 100.0,
-      "crap": 13.0
     },
     {
       "file": "./src/parsers/parse_makefile.rs",
@@ -379,6 +379,22 @@
       "crap": 10.0
     },
     {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::name",
+      "line": 29,
+      "cyclomatic": 10.0,
+      "coverage": 100.0,
+      "crap": 10.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::config_path",
+      "line": 43,
+      "cyclomatic": 10.0,
+      "coverage": 100.0,
+      "crap": 10.0
+    },
+    {
       "file": "./src/parsers/parse_justfile.rs",
       "function": "parse",
       "line": 7,
@@ -409,14 +425,6 @@
       "cyclomatic": 9.0,
       "coverage": 100.0,
       "crap": 9.0
-    },
-    {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::append_initial_output",
-      "line": 213,
-      "cyclomatic": 6.0,
-      "coverage": 57.14285714285714,
-      "crap": 8.833819241982507
     },
     {
       "file": "./src/allowlist.rs",
@@ -475,14 +483,6 @@
       "crap": 8.0
     },
     {
-      "file": "./src/commands/mcp.rs",
-      "function": "Editor::template",
-      "line": 67,
-      "cyclomatic": 6.0,
-      "coverage": 62.5,
-      "crap": 7.8984375
-    },
-    {
       "file": "./src/task_discovery/disambiguation.rs",
       "function": "generate_prefix_from_short_name",
       "line": 56,
@@ -493,7 +493,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_stop",
-      "line": 1172,
+      "line": 1237,
       "cyclomatic": 7.0,
       "coverage": 76.74418604651163,
       "crap": 7.616297936030789
@@ -501,7 +501,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::update_job_state",
-      "line": 384,
+      "line": 441,
       "cyclomatic": 5.0,
       "coverage": 53.333333333333336,
       "crap": 7.540740740740741
@@ -509,10 +509,10 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::push_line",
-      "line": 63,
+      "line": 83,
       "cyclomatic": 7.0,
-      "coverage": 80.0,
-      "crap": 7.3919999999999995
+      "coverage": 81.25,
+      "crap": 7.322998046875
     },
     {
       "file": "./src/parsers/parse_github_actions.rs",
@@ -539,6 +539,14 @@
       "crap": 7.0066083379692845
     },
     {
+      "file": "./src/commands/mcp.rs",
+      "function": "merge_dela_into_json",
+      "line": 100,
+      "cyclomatic": 7.0,
+      "coverage": 96.0,
+      "crap": 7.003136
+    },
+    {
       "file": "./src/parsers/parse_makefile.rs",
       "function": "collapse_line_continuations",
       "line": 157,
@@ -563,14 +571,6 @@
       "crap": 7.0
     },
     {
-      "file": "./src/commands/mcp.rs",
-      "function": "Editor::name",
-      "line": 46,
-      "cyclomatic": 6.0,
-      "coverage": 75.0,
-      "crap": 6.5625
-    },
-    {
       "file": "./src/allowlist.rs",
       "function": "save_allowlist",
       "line": 40,
@@ -581,7 +581,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::record_completed_job",
-      "line": 324,
+      "line": 381,
       "cyclomatic": 6.0,
       "coverage": 93.54838709677419,
       "crap": 6.009667349199423
@@ -628,8 +628,16 @@
     },
     {
       "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::add_job_output_chunks",
+      "line": 220,
+      "cyclomatic": 6.0,
+      "coverage": 100.0,
+      "crap": 6.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::send_task_output",
-      "line": 280,
+      "line": 306,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -637,7 +645,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::serve_stdio",
-      "line": 338,
+      "line": 364,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -645,7 +653,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::initialize",
-      "line": 1251,
+      "line": 1316,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -707,22 +715,6 @@
       "crap": 6.0
     },
     {
-      "file": "./src/commands/mcp.rs",
-      "function": "Editor::config_path",
-      "line": 56,
-      "cyclomatic": 6.0,
-      "coverage": 100.0,
-      "crap": 6.0
-    },
-    {
-      "file": "./src/commands/mcp.rs",
-      "function": "merge_dela_into_json",
-      "line": 110,
-      "cyclomatic": 6.0,
-      "coverage": 100.0,
-      "crap": 6.0
-    },
-    {
       "file": "./src/task_discovery/maven.rs",
       "function": "discover_maven_tasks",
       "line": 15,
@@ -731,9 +723,17 @@
       "crap": 5.404663923182442
     },
     {
+      "file": "./src/commands/mcp.rs",
+      "function": "Editor::servers_key",
+      "line": 68,
+      "cyclomatic": 5.0,
+      "coverage": 85.71428571428571,
+      "crap": 5.072886297376093
+    },
+    {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_stats",
-      "line": 685,
+      "line": 753,
       "cyclomatic": 5.0,
       "coverage": 88.23529411764706,
       "crap": 5.0407083248524325
@@ -787,6 +787,14 @@
       "crap": 5.0
     },
     {
+      "file": "./src/commands/mcp.rs",
+      "function": "merge_dela_into_toml",
+      "line": 134,
+      "cyclomatic": 5.0,
+      "coverage": 100.0,
+      "crap": 5.0
+    },
+    {
       "file": "./src/task_discovery/turbo.rs",
       "function": "build_turbo_package_config_index",
       "line": 348,
@@ -817,22 +825,6 @@
       "cyclomatic": 4.0,
       "coverage": 76.47058823529412,
       "crap": 4.208426623244454
-    },
-    {
-      "file": "./src/commands/mcp.rs",
-      "function": "merge_dela_into_toml",
-      "line": 140,
-      "cyclomatic": 4.0,
-      "coverage": 82.6086956521739,
-      "crap": 4.084162077751294
-    },
-    {
-      "file": "./src/commands/mcp.rs",
-      "function": "Editor::servers_key",
-      "line": 85,
-      "cyclomatic": 4.0,
-      "coverage": 83.33333333333334,
-      "crap": 4.0740740740740735
     },
     {
       "file": "./src/task_discovery/cmake.rs",
@@ -873,14 +865,6 @@
       "cyclomatic": 4.0,
       "coverage": 93.75,
       "crap": 4.00390625
-    },
-    {
-      "file": "./src/mcp/server.rs",
-      "function": "OutputNotificationBatch::take_notification_data",
-      "line": 108,
-      "cyclomatic": 4.0,
-      "coverage": 95.65217391304348,
-      "crap": 4.001315032464864
     },
     {
       "file": "./src/parsers/parse_pom_xml.rs",
@@ -932,11 +916,27 @@
     },
     {
       "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::resolve_wait_for_exit_seconds",
-      "line": 260,
+      "function": "OutputNotificationBatch::take_notification_data",
+      "line": 108,
       "cyclomatic": 4.0,
       "coverage": 100.0,
       "crap": 4.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::resolve_wait_for_exit_seconds",
+      "line": 286,
+      "cyclomatic": 4.0,
+      "coverage": 100.0,
+      "crap": 4.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::get_output_lines",
+      "line": 249,
+      "cyclomatic": 3.0,
+      "coverage": 80.0,
+      "crap": 3.072
     },
     {
       "file": "./src/mcp/server.rs",
@@ -949,7 +949,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::start_job",
-      "line": 283,
+      "line": 340,
       "cyclomatic": 3.0,
       "coverage": 86.20689655172413,
       "crap": 3.0236172044774285
@@ -965,7 +965,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::remove_job",
-      "line": 617,
+      "line": 685,
       "cyclomatic": 3.0,
       "coverage": 88.88888888888889,
       "crap": 3.0123456790123457
@@ -1059,9 +1059,9 @@
       "crap": 3.0
     },
     {
-      "file": "./src/mcp/job_manager.rs",
-      "function": "Job::get_output_lines",
-      "line": 192,
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::append_output_chunk",
+      "line": 213,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0
@@ -1069,7 +1069,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::get_discovered_tasks",
-      "line": 317,
+      "line": 343,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0
@@ -1133,7 +1133,7 @@
     {
       "file": "./src/commands/mcp.rs",
       "function": "Editor::dela_marker",
-      "line": 77,
+      "line": 60,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0
@@ -1141,7 +1141,7 @@
     {
       "file": "./src/commands/mcp.rs",
       "function": "Editor::dela_json_entry",
-      "line": 94,
+      "line": 83,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0
@@ -1157,7 +1157,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::flush_output_notification_batch",
-      "line": 233,
+      "line": 259,
       "cyclomatic": 2.0,
       "coverage": 58.82352941176471,
       "crap": 2.2792591084876856
@@ -1165,7 +1165,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::can_start_job",
-      "line": 269,
+      "line": 326,
       "cyclomatic": 2.0,
       "coverage": 66.66666666666666,
       "crap": 2.1481481481481484
@@ -1177,14 +1177,6 @@
       "cyclomatic": 2.0,
       "coverage": 80.0,
       "crap": 2.032
-    },
-    {
-      "file": "./src/mcp/job_manager.rs",
-      "function": "JobManager::add_job_output",
-      "line": 404,
-      "cyclomatic": 2.0,
-      "coverage": 85.71428571428571,
-      "crap": 2.011661807580175
     },
     {
       "file": "./src/commands/list.rs",
@@ -1201,6 +1193,14 @@
       "cyclomatic": 2.0,
       "coverage": 90.0,
       "crap": 2.004
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::add_job_output_chunk",
+      "line": 467,
+      "cyclomatic": 2.0,
+      "coverage": 91.66666666666666,
+      "crap": 2.002314814814815
     },
     {
       "file": "./src/parsers/parse_pom_xml.rs",
@@ -1372,8 +1372,8 @@
     },
     {
       "file": "./src/mcp/job_manager.rs",
-      "function": "RingBuffer::get_last_lines",
-      "line": 88,
+      "function": "RingBuffer::get_last_entries",
+      "line": 110,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
@@ -1381,7 +1381,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::is_empty",
-      "line": 110,
+      "line": 161,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1389,7 +1389,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::add_output",
-      "line": 183,
+      "line": 234,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
@@ -1397,7 +1397,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::idle_time",
-      "line": 213,
+      "line": 270,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1420,8 +1420,16 @@
     },
     {
       "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::truncate_output_entry_for_chunk",
+      "line": 250,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::list_tasks",
-      "line": 356,
+      "line": 382,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
@@ -1429,7 +1437,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::list_tools",
-      "line": 1343,
+      "line": 1408,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1437,7 +1445,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level",
-      "line": 1670,
+      "line": 1751,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -2012,8 +2020,48 @@
     },
     {
       "file": "./src/mcp/job_manager.rs",
+      "function": "OutputLine::new",
+      "line": 50,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "OutputLine::len",
+      "line": 57,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::new",
-      "line": 53,
+      "line": 73,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::get_all_entries",
+      "line": 122,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::get_entries_from",
+      "line": 127,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "RingBuffer::get_last_lines",
+      "line": 138,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2021,7 +2069,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::get_all_lines",
-      "line": 99,
+      "line": 147,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2029,7 +2077,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::len",
-      "line": 104,
+      "line": 155,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2037,7 +2085,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::is_full",
-      "line": 115,
+      "line": 166,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2045,7 +2093,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::capacity",
-      "line": 120,
+      "line": 171,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2053,7 +2101,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::total_bytes",
-      "line": 125,
+      "line": 176,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2061,7 +2109,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::new",
-      "line": 144,
+      "line": 195,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2069,7 +2117,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::touch",
-      "line": 162,
+      "line": 213,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2077,7 +2125,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::mark_exited",
-      "line": 167,
+      "line": 218,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2085,7 +2133,15 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::mark_failed",
-      "line": 175,
+      "line": 226,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::get_output_entries_from",
+      "line": 243,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2093,7 +2149,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::is_running",
-      "line": 200,
+      "line": 257,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2101,7 +2157,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::age",
-      "line": 206,
+      "line": 263,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2109,7 +2165,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManagerConfig::default",
-      "line": 231,
+      "line": 288,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2117,7 +2173,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::new",
-      "line": 254,
+      "line": 311,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2125,7 +2181,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::with_config",
-      "line": 259,
+      "line": 316,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2133,7 +2189,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_job",
-      "line": 363,
+      "line": 420,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2141,7 +2197,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_all_jobs",
-      "line": 369,
+      "line": 426,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2149,7 +2205,15 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_jobs_by_name",
-      "line": 375,
+      "line": 432,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::add_job_output",
+      "line": 462,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2212,8 +2276,16 @@
     },
     {
       "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::output_entries_to_json",
+      "line": 240,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::output_flush_timer_deadline",
-      "line": 253,
+      "line": 279,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2221,7 +2293,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::send_task_event",
-      "line": 298,
+      "line": 324,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2229,7 +2301,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::root",
-      "line": 313,
+      "line": 339,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2237,7 +2309,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::status",
-      "line": 383,
+      "line": 409,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2245,7 +2317,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_status",
-      "line": 1034,
+      "line": 1075,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2253,7 +2325,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::get_info",
-      "line": 1232,
+      "line": 1297,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2261,7 +2333,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1682,
+      "line": 1763,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2269,7 +2341,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1688,
+      "line": 1769,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2363,6 +2435,22 @@
       "crap": 1.0
     },
     {
+      "file": "./src/mcp/dto.rs",
+      "function": "OutputChunkDto::stdout",
+      "line": 638,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/dto.rs",
+      "function": "OutputChunkDto::stderr",
+      "line": 645,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
       "file": "./src/repo_root.rs",
       "function": "find_git_repo_root",
       "line": 24,
@@ -2396,8 +2484,16 @@
     },
     {
       "file": "./src/commands/mcp.rs",
+      "function": "dela_executable_path",
+      "line": 6,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/commands/mcp.rs",
       "function": "generate_config",
-      "line": 237,
+      "line": 242,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -40,7 +40,7 @@ impl Editor {
         }
     }
 
-    fn config_path(&self) -> PathBuf {
+    pub(crate) fn config_path(&self) -> PathBuf {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("~"));
         match self {
             Editor::Cursor => home.join(".cursor/mcp.json"),

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -20,6 +20,9 @@ pub enum Editor {
     Gemini,
     ClaudeCode,
     Antigravity,
+    Cline,
+    OpenCode,
+    Crush,
 }
 
 impl Editor {
@@ -31,6 +34,9 @@ impl Editor {
             Editor::Gemini => "Gemini CLI",
             Editor::ClaudeCode => "Claude Code",
             Editor::Antigravity => "Antigravity",
+            Editor::Cline => "Cline",
+            Editor::OpenCode => "OpenCode",
+            Editor::Crush => "Crush",
         }
     }
 
@@ -43,6 +49,11 @@ impl Editor {
             Editor::Gemini => home.join(".gemini/settings.json"),
             Editor::ClaudeCode => home.join(".claude-code/settings.json"),
             Editor::Antigravity => home.join(".gemini/antigravity-ide/mcp_config.json"),
+            Editor::Cline => std::env::var("CLINE_MCP_SETTINGS_PATH")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| home.join(".cline/data/settings/cline_mcp_settings.json")),
+            Editor::OpenCode => home.join(".config/opencode/opencode.json"),
+            Editor::Crush => home.join(".config/crush/crush.json"),
         }
     }
 
@@ -56,9 +67,10 @@ impl Editor {
     /// The top-level key under which MCP server entries live
     fn servers_key(&self) -> &'static str {
         match self {
-            Editor::Cursor | Editor::Gemini | Editor::ClaudeCode | Editor::Antigravity => "mcpServers",
+            Editor::Cursor | Editor::Gemini | Editor::ClaudeCode | Editor::Antigravity | Editor::Cline | Editor::Crush => "mcpServers",
             Editor::Vscode => "servers",
             Editor::Codex => "mcp_servers",
+            Editor::OpenCode => "mcp",
         }
     }
 
@@ -239,6 +251,9 @@ pub async fn execute(
     init_gemini: bool,
     init_claude_code: bool,
     init_antigravity: bool,
+    init_cline: bool,
+    init_opencode: bool,
+    init_crush: bool,
 ) -> anyhow::Result<()> {
     // Resolve the path relative to the current working directory
     let root_path = if cwd == "." {
@@ -249,7 +264,15 @@ pub async fn execute(
     };
 
     // Handle config generation flags
-    let has_init_flag = init_cursor || init_vscode || init_codex || init_gemini || init_claude_code || init_antigravity;
+    let has_init_flag = init_cursor
+        || init_vscode
+        || init_codex
+        || init_gemini
+        || init_claude_code
+        || init_antigravity
+        || init_cline
+        || init_opencode
+        || init_crush;
 
     if has_init_flag {
         if init_cursor {
@@ -269,6 +292,15 @@ pub async fn execute(
         }
         if init_antigravity {
             generate_config(Editor::Antigravity)?;
+        }
+        if init_cline {
+            generate_config(Editor::Cline)?;
+        }
+        if init_opencode {
+            generate_config(Editor::OpenCode)?;
+        }
+        if init_crush {
+            generate_config(Editor::Crush)?;
         }
         return Ok(());
     }
@@ -491,6 +523,33 @@ mod tests {
             Editor::Antigravity.config_path(),
             home.join(".gemini/antigravity-ide/mcp_config.json")
         );
+        assert_eq!(
+            Editor::Cline.config_path(),
+            home.join(".cline/data/settings/cline_mcp_settings.json")
+        );
+        assert_eq!(
+            Editor::OpenCode.config_path(),
+            home.join(".config/opencode/opencode.json")
+        );
+        assert_eq!(
+            Editor::Crush.config_path(),
+            home.join(".config/crush/crush.json")
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_cline_config_path_override() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let override_path = temp_dir.path().join("custom_cline_settings.json");
+        unsafe {
+            std::env::set_var("CLINE_MCP_SETTINGS_PATH", &override_path);
+        }
+        let config_path = Editor::Cline.config_path();
+        unsafe {
+            std::env::remove_var("CLINE_MCP_SETTINGS_PATH");
+        }
+        assert_eq!(config_path, override_path);
     }
 
     struct TestEnvGuard {
@@ -532,7 +591,19 @@ mod tests {
             std::env::set_var("HOME", temp_dir.path());
         }
 
-        let result = execute(".".to_string(), true, false, false, false, false, false).await;
+        let result = execute(
+            ".".to_string(),
+            true,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+        )
+        .await;
         if let Err(ref e) = result {
             panic!("execute failed with error: {:?}", e);
         }

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -67,7 +67,12 @@ impl Editor {
     /// The top-level key under which MCP server entries live
     fn servers_key(&self) -> &'static str {
         match self {
-            Editor::Cursor | Editor::Gemini | Editor::ClaudeCode | Editor::Antigravity | Editor::Cline | Editor::Crush => "mcpServers",
+            Editor::Cursor
+            | Editor::Gemini
+            | Editor::ClaudeCode
+            | Editor::Antigravity
+            | Editor::Cline
+            | Editor::Crush => "mcpServers",
             Editor::Vscode => "servers",
             Editor::Codex => "mcp_servers",
             Editor::OpenCode => "mcp",
@@ -148,10 +153,7 @@ fn merge_dela_into_toml(existing: &str) -> anyhow::Result<String> {
 
     let exe_path = dela_executable_path();
     let mut dela = toml::map::Map::new();
-    dela.insert(
-        "command".to_string(),
-        toml::Value::String(exe_path),
-    );
+    dela.insert("command".to_string(), toml::Value::String(exe_path));
     dela.insert(
         "args".to_string(),
         toml::Value::Array(vec![toml::Value::String("mcp".to_string())]),
@@ -243,18 +245,7 @@ fn generate_config(editor: Editor) -> anyhow::Result<()> {
 }
 
 /// Execute the MCP command
-pub async fn execute(
-    cwd: String,
-    init_cursor: bool,
-    init_vscode: bool,
-    init_codex: bool,
-    init_gemini: bool,
-    init_claude_code: bool,
-    init_antigravity: bool,
-    init_cline: bool,
-    init_opencode: bool,
-    init_crush: bool,
-) -> anyhow::Result<()> {
+pub async fn execute(cwd: String, init_editor: Option<Editor>) -> anyhow::Result<()> {
     // Resolve the path relative to the current working directory
     let root_path = if cwd == "." {
         std::env::current_dir()
@@ -263,45 +254,8 @@ pub async fn execute(
         PathBuf::from(&cwd)
     };
 
-    // Handle config generation flags
-    let has_init_flag = init_cursor
-        || init_vscode
-        || init_codex
-        || init_gemini
-        || init_claude_code
-        || init_antigravity
-        || init_cline
-        || init_opencode
-        || init_crush;
-
-    if has_init_flag {
-        if init_cursor {
-            generate_config(Editor::Cursor)?;
-        }
-        if init_vscode {
-            generate_config(Editor::Vscode)?;
-        }
-        if init_codex {
-            generate_config(Editor::Codex)?;
-        }
-        if init_gemini {
-            generate_config(Editor::Gemini)?;
-        }
-        if init_claude_code {
-            generate_config(Editor::ClaudeCode)?;
-        }
-        if init_antigravity {
-            generate_config(Editor::Antigravity)?;
-        }
-        if init_cline {
-            generate_config(Editor::Cline)?;
-        }
-        if init_opencode {
-            generate_config(Editor::OpenCode)?;
-        }
-        if init_crush {
-            generate_config(Editor::Crush)?;
-        }
+    if let Some(editor) = init_editor {
+        generate_config(editor)?;
         return Ok(());
     }
 
@@ -574,6 +528,24 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_editor_names_exhaustive() {
+        for editor in &[
+            Editor::Cursor,
+            Editor::Vscode,
+            Editor::Codex,
+            Editor::Gemini,
+            Editor::ClaudeCode,
+            Editor::Antigravity,
+            Editor::Cline,
+            Editor::OpenCode,
+            Editor::Crush,
+        ] {
+            let name = editor.name();
+            assert!(!name.is_empty());
+        }
+    }
+
     #[tokio::test]
     #[serial_test::serial]
     async fn test_execute_init_cursor() {
@@ -593,15 +565,7 @@ mod tests {
 
         let result = execute(
             ".".to_string(),
-            true,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
+            Some(Editor::Cursor),
         )
         .await;
         if let Err(ref e) = result {

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -496,12 +496,17 @@ mod tests {
     fn test_cline_config_path_override() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let override_path = temp_dir.path().join("custom_cline_settings.json");
+        let old_cline_path = std::env::var("CLINE_MCP_SETTINGS_PATH").ok();
         unsafe {
             std::env::set_var("CLINE_MCP_SETTINGS_PATH", &override_path);
         }
         let config_path = Editor::Cline.config_path();
         unsafe {
-            std::env::remove_var("CLINE_MCP_SETTINGS_PATH");
+            if let Some(ref val) = old_cline_path {
+                std::env::set_var("CLINE_MCP_SETTINGS_PATH", val);
+            } else {
+                std::env::remove_var("CLINE_MCP_SETTINGS_PATH");
+            }
         }
         assert_eq!(config_path, override_path);
     }
@@ -563,11 +568,7 @@ mod tests {
             std::env::set_var("HOME", temp_dir.path());
         }
 
-        let result = execute(
-            ".".to_string(),
-            Some(Editor::Cursor),
-        )
-        .await;
+        let result = execute(".".to_string(), Some(Editor::Cursor)).await;
         if let Err(ref e) = result {
             panic!("execute failed with error: {:?}", e);
         }

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -3,34 +3,13 @@ use anyhow::Context;
 use std::fs;
 use std::path::PathBuf;
 
-/// MCP config template for editors using mcpServers format (Cursor, Gemini CLI)
-const MCP_SERVERS_JSON_TEMPLATE: &str = r#"{
-  "mcpServers": {
-    "dela": {
-      "command": "dela",
-      "args": ["mcp"]
-    }
-  }
+fn dela_executable_path() -> String {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.canonicalize().ok())
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "dela".to_string())
 }
-"#;
-
-/// MCP config template for VSCode (.vscode/mcp.json)
-const VSCODE_CONFIG_TEMPLATE: &str = r#"{
-  "servers": {
-    "dela": {
-      "type": "stdio",
-      "command": "dela",
-      "args": ["mcp"]
-    }
-  }
-}
-"#;
-
-/// MCP config template for OpenAI Codex (~/.codex/config.toml)
-const CODEX_CONFIG_TEMPLATE: &str = r#"[mcp_servers.dela]
-command = "dela"
-args = ["mcp"]
-"#;
 
 /// Supported editors for MCP config generation
 #[derive(Debug, Clone, Copy)]
@@ -40,6 +19,7 @@ pub enum Editor {
     Codex,
     Gemini,
     ClaudeCode,
+    Antigravity,
 }
 
 impl Editor {
@@ -50,6 +30,7 @@ impl Editor {
             Editor::Codex => "OpenAI Codex",
             Editor::Gemini => "Gemini CLI",
             Editor::ClaudeCode => "Claude Code",
+            Editor::Antigravity => "Antigravity",
         }
     }
 
@@ -61,16 +42,7 @@ impl Editor {
             Editor::Codex => home.join(".codex/config.toml"),
             Editor::Gemini => home.join(".gemini/settings.json"),
             Editor::ClaudeCode => home.join(".claude-code/settings.json"),
-        }
-    }
-
-    fn template(&self) -> &'static str {
-        match self {
-            Editor::Cursor => MCP_SERVERS_JSON_TEMPLATE,
-            Editor::Vscode => VSCODE_CONFIG_TEMPLATE,
-            Editor::Codex => CODEX_CONFIG_TEMPLATE,
-            Editor::Gemini => MCP_SERVERS_JSON_TEMPLATE,
-            Editor::ClaudeCode => MCP_SERVERS_JSON_TEMPLATE,
+            Editor::Antigravity => home.join(".gemini/antigravity-ide/mcp_config.json"),
         }
     }
 
@@ -84,7 +56,7 @@ impl Editor {
     /// The top-level key under which MCP server entries live
     fn servers_key(&self) -> &'static str {
         match self {
-            Editor::Cursor | Editor::Gemini | Editor::ClaudeCode => "mcpServers",
+            Editor::Cursor | Editor::Gemini | Editor::ClaudeCode | Editor::Antigravity => "mcpServers",
             Editor::Vscode => "servers",
             Editor::Codex => "mcp_servers",
         }
@@ -92,14 +64,15 @@ impl Editor {
 
     /// The dela entry as a serde_json::Value (for JSON-based editors)
     fn dela_json_entry(&self) -> serde_json::Value {
+        let exe_path = dela_executable_path();
         match self {
             Editor::Vscode => serde_json::json!({
                 "type": "stdio",
-                "command": "dela",
+                "command": exe_path,
                 "args": ["mcp"]
             }),
             _ => serde_json::json!({
-                "command": "dela",
+                "command": exe_path,
                 "args": ["mcp"]
             }),
         }
@@ -108,8 +81,12 @@ impl Editor {
 
 /// Merge dela into an existing JSON config file (Cursor, VSCode, Gemini, Claude Code)
 fn merge_dela_into_json(editor: Editor, existing: &str) -> anyhow::Result<String> {
-    let mut root: serde_json::Value = serde_json::from_str(existing)
-        .map_err(|e| anyhow::anyhow!("Failed to parse config as JSON: {}", e))?;
+    let mut root: serde_json::Value = if existing.trim().is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_str(existing)
+            .map_err(|e| anyhow::anyhow!("Failed to parse config as JSON: {}", e))?
+    };
 
     let obj = root
         .as_object_mut()
@@ -138,8 +115,12 @@ fn merge_dela_into_json(editor: Editor, existing: &str) -> anyhow::Result<String
 
 /// Merge dela into an existing TOML config file (Codex)
 fn merge_dela_into_toml(existing: &str) -> anyhow::Result<String> {
-    let mut table: toml::Table = toml::from_str(existing)
-        .map_err(|e| anyhow::anyhow!("Failed to parse config as TOML: {}", e))?;
+    let mut table: toml::Table = if existing.trim().is_empty() {
+        toml::Table::new()
+    } else {
+        toml::from_str(existing)
+            .map_err(|e| anyhow::anyhow!("Failed to parse config as TOML: {}", e))?
+    };
 
     if !table.contains_key("mcp_servers") {
         table.insert(
@@ -153,10 +134,11 @@ fn merge_dela_into_toml(existing: &str) -> anyhow::Result<String> {
         .and_then(|v| v.as_table_mut())
         .context("'mcp_servers' in config is not a table")?;
 
+    let exe_path = dela_executable_path();
     let mut dela = toml::map::Map::new();
     dela.insert(
         "command".to_string(),
-        toml::Value::String("dela".to_string()),
+        toml::Value::String(exe_path),
     );
     dela.insert(
         "args".to_string(),
@@ -220,8 +202,17 @@ fn generate_config_at(editor: Editor, config_path: &PathBuf) -> anyhow::Result<(
         return Ok(());
     }
 
-    // Write the config file
-    fs::write(config_path, editor.template())
+    // Write the config file using merge functions on empty config to generate absolute path
+    let initial_content = match editor {
+        Editor::Codex => "".to_string(),
+        _ => "{}".to_string(),
+    };
+    let content = match editor {
+        Editor::Codex => merge_dela_into_toml(&initial_content)?,
+        _ => merge_dela_into_json(editor, &initial_content)?,
+    };
+
+    fs::write(config_path, content)
         .map_err(|e| anyhow::anyhow!("Failed to write config file: {}", e))?;
 
     eprintln!(
@@ -247,6 +238,7 @@ pub async fn execute(
     init_codex: bool,
     init_gemini: bool,
     init_claude_code: bool,
+    init_antigravity: bool,
 ) -> anyhow::Result<()> {
     // Resolve the path relative to the current working directory
     let root_path = if cwd == "." {
@@ -257,7 +249,7 @@ pub async fn execute(
     };
 
     // Handle config generation flags
-    let has_init_flag = init_cursor || init_vscode || init_codex || init_gemini || init_claude_code;
+    let has_init_flag = init_cursor || init_vscode || init_codex || init_gemini || init_claude_code || init_antigravity;
 
     if has_init_flag {
         if init_cursor {
@@ -274,6 +266,9 @@ pub async fn execute(
         }
         if init_claude_code {
             generate_config(Editor::ClaudeCode)?;
+        }
+        if init_antigravity {
+            generate_config(Editor::Antigravity)?;
         }
         return Ok(());
     }
@@ -312,7 +307,8 @@ mod tests {
 
         let content = fs::read_to_string(&config_path).unwrap();
         assert!(content.contains("\"dela\""));
-        assert!(content.contains("\"command\": \"dela\""));
+        let expected_cmd = format!("\"command\": \"{}\"", dela_executable_path());
+        assert!(content.contains(&expected_cmd));
     }
 
     #[test]
@@ -327,6 +323,8 @@ mod tests {
         let content = fs::read_to_string(&config_path).unwrap();
         assert!(content.contains("\"servers\""));
         assert!(content.contains("\"type\": \"stdio\""));
+        let expected_cmd = format!("\"command\": \"{}\"", dela_executable_path());
+        assert!(content.contains(&expected_cmd));
     }
 
     #[test]
@@ -374,7 +372,8 @@ mod tests {
         assert!(content.contains("\"command\": \"other\""));
         // Adds dela
         assert!(content.contains("\"dela\""));
-        assert!(content.contains("\"command\": \"dela\""));
+        let expected_cmd = format!("\"command\": \"{}\"", dela_executable_path());
+        assert!(content.contains(&expected_cmd));
     }
 
     #[test]
@@ -407,7 +406,8 @@ mod tests {
         // Adds dela with VSCode-specific format
         assert!(content.contains("\"dela\""));
         assert!(content.contains("\"type\": \"stdio\""));
-        assert!(content.contains("\"command\": \"dela\""));
+        let expected_cmd = format!("\"command\": \"{}\"", dela_executable_path());
+        assert!(content.contains(&expected_cmd));
     }
 
     #[test]
@@ -450,7 +450,8 @@ mod tests {
         assert!(content.contains("other"));
         // Adds dela
         assert!(content.contains("[mcp_servers.dela]"));
-        assert!(content.contains("command = \"dela\""));
+        let expected_cmd = format!("command = \"{}\"", dela_executable_path());
+        assert!(content.contains(&expected_cmd));
     }
 
     #[test]
@@ -485,6 +486,10 @@ mod tests {
         assert_eq!(
             Editor::ClaudeCode.config_path(),
             home.join(".claude-code/settings.json")
+        );
+        assert_eq!(
+            Editor::Antigravity.config_path(),
+            home.join(".gemini/antigravity-ide/mcp_config.json")
         );
     }
 
@@ -527,7 +532,7 @@ mod tests {
             std::env::set_var("HOME", temp_dir.path());
         }
 
-        let result = execute(".".to_string(), true, false, false, false, false).await;
+        let result = execute(".".to_string(), true, false, false, false, false, false).await;
         if let Err(ref e) = result {
             panic!("execute failed with error: {:?}", e);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,24 @@ async fn run_command(command: Commands) -> anyhow::Result<()> {
             init_opencode,
             init_crush,
         } => {
+            let init_flags = [
+                init_cursor,
+                init_vscode,
+                init_codex,
+                init_gemini,
+                init_claude_code,
+                init_antigravity,
+                init_cline,
+                init_opencode,
+                init_crush,
+            ];
+            let init_count = init_flags.iter().filter(|&&x| x).count();
+            if init_count > 1 {
+                return Err(anyhow::anyhow!(
+                    "Only one --init-* flag can be specified at a time"
+                ));
+            }
+
             let init_editor = if init_cursor {
                 Some(commands::mcp::Editor::Cursor)
             } else if init_vscode {
@@ -377,6 +395,28 @@ mod tests {
             let result = run_command(cmd).await;
             assert!(result.is_ok());
         }
+    }
+
+    #[tokio::test]
+    async fn test_run_command_mcp_conflicting_flags() {
+        let cmd = Commands::Mcp {
+            cwd: ".".to_string(),
+            init_cursor: true,
+            init_vscode: true,
+            init_codex: false,
+            init_gemini: false,
+            init_claude_code: false,
+            init_antigravity: false,
+            init_cline: false,
+            init_opencode: false,
+            init_crush: false,
+        };
+        let result = run_command(cmd).await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Only one --init-* flag can be specified at a time"
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,19 +209,28 @@ async fn run_command(command: Commands) -> anyhow::Result<()> {
             init_opencode,
             init_crush,
         } => {
-            commands::mcp::execute(
-                cwd,
-                init_cursor,
-                init_vscode,
-                init_codex,
-                init_gemini,
-                init_claude_code,
-                init_antigravity,
-                init_cline,
-                init_opencode,
-                init_crush,
-            )
-            .await
+            let init_editor = if init_cursor {
+                Some(commands::mcp::Editor::Cursor)
+            } else if init_vscode {
+                Some(commands::mcp::Editor::Vscode)
+            } else if init_codex {
+                Some(commands::mcp::Editor::Codex)
+            } else if init_gemini {
+                Some(commands::mcp::Editor::Gemini)
+            } else if init_claude_code {
+                Some(commands::mcp::Editor::ClaudeCode)
+            } else if init_antigravity {
+                Some(commands::mcp::Editor::Antigravity)
+            } else if init_cline {
+                Some(commands::mcp::Editor::Cline)
+            } else if init_opencode {
+                Some(commands::mcp::Editor::OpenCode)
+            } else if init_crush {
+                Some(commands::mcp::Editor::Crush)
+            } else {
+                None
+            };
+            commands::mcp::execute(cwd, init_editor).await
         }
         Commands::Init => commands::init::execute(),
         Commands::ConfigureShell => commands::configure_shell::execute(),
@@ -302,6 +311,72 @@ mod tests {
             lines[1], "Error: Failed to execute task",
             "Regular error should have 'Error:' prefix"
         );
+    }
+
+    struct TestEnvGuard {
+        old_dir: Option<std::path::PathBuf>,
+        old_home: Option<String>,
+    }
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            if let Some(ref dir) = self.old_dir {
+                let _ = std::env::set_current_dir(dir);
+            }
+            if let Some(ref home) = self.old_home {
+                unsafe {
+                    std::env::set_var("HOME", home);
+                }
+            } else {
+                unsafe {
+                    std::env::remove_var("HOME");
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_run_command_mcp_all_flags() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let _guard = TestEnvGuard {
+            old_dir: std::env::current_dir().ok(),
+            old_home: std::env::var("HOME").ok(),
+        };
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+        unsafe {
+            std::env::set_var("HOME", temp_dir.path());
+        }
+
+        // Test each flag to ensure the match arm is evaluated and runs generate_config
+        let flags = vec![
+            (true, false, false, false, false, false, false, false, false), // Cursor
+            (false, true, false, false, false, false, false, false, false), // Vscode
+            (false, false, true, false, false, false, false, false, false), // Codex
+            (false, false, false, true, false, false, false, false, false), // Gemini
+            (false, false, false, false, true, false, false, false, false), // ClaudeCode
+            (false, false, false, false, false, true, false, false, false), // Antigravity
+            (false, false, false, false, false, false, true, false, false), // Cline
+            (false, false, false, false, false, false, false, true, false), // OpenCode
+            (false, false, false, false, false, false, false, false, true), // Crush
+        ];
+
+        for f in flags {
+            let cmd = Commands::Mcp {
+                cwd: ".".to_string(),
+                init_cursor: f.0,
+                init_vscode: f.1,
+                init_codex: f.2,
+                init_gemini: f.3,
+                init_claude_code: f.4,
+                init_antigravity: f.5,
+                init_cline: f.6,
+                init_opencode: f.7,
+                init_crush: f.8,
+            };
+            let result = run_command(cmd).await;
+            assert!(result.is_ok());
+        }
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,18 @@ enum Commands {
         /// Generate ~/.gemini/antigravity-ide/mcp_config.json for Antigravity
         #[arg(long)]
         init_antigravity: bool,
+
+        /// Generate ~/.cline/data/settings/cline_mcp_settings.json for Cline
+        #[arg(long)]
+        init_cline: bool,
+
+        /// Generate ~/.config/opencode/opencode.json for OpenCode
+        #[arg(long)]
+        init_opencode: bool,
+
+        /// Generate ~/.config/crush/crush.json for Crush
+        #[arg(long)]
+        init_crush: bool,
     },
 
     /// Initialize dela and configure shell integration
@@ -193,6 +205,9 @@ async fn run_command(command: Commands) -> anyhow::Result<()> {
             init_gemini,
             init_claude_code,
             init_antigravity,
+            init_cline,
+            init_opencode,
+            init_crush,
         } => {
             commands::mcp::execute(
                 cwd,
@@ -202,6 +217,9 @@ async fn run_command(command: Commands) -> anyhow::Result<()> {
                 init_gemini,
                 init_claude_code,
                 init_antigravity,
+                init_cline,
+                init_opencode,
+                init_crush,
             )
             .await
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,6 +287,7 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::{Commands, run_command};
+    use crate::commands::mcp::Editor;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -368,32 +369,147 @@ mod tests {
 
         // Test each flag to ensure the match arm is evaluated and runs generate_config
         let flags = vec![
-            (true, false, false, false, false, false, false, false, false), // Cursor
-            (false, true, false, false, false, false, false, false, false), // Vscode
-            (false, false, true, false, false, false, false, false, false), // Codex
-            (false, false, false, true, false, false, false, false, false), // Gemini
-            (false, false, false, false, true, false, false, false, false), // ClaudeCode
-            (false, false, false, false, false, true, false, false, false), // Antigravity
-            (false, false, false, false, false, false, true, false, false), // Cline
-            (false, false, false, false, false, false, false, true, false), // OpenCode
-            (false, false, false, false, false, false, false, false, true), // Crush
+            (
+                Editor::Cursor,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ), // Cursor
+            (
+                Editor::Vscode,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ), // Vscode
+            (
+                Editor::Codex,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ), // Codex
+            (
+                Editor::Gemini,
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+            ), // Gemini
+            (
+                Editor::ClaudeCode,
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+                false,
+            ), // ClaudeCode
+            (
+                Editor::Antigravity,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+                false,
+            ), // Antigravity
+            (
+                Editor::Cline,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+                false,
+            ), // Cline
+            (
+                Editor::OpenCode,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true,
+                false,
+            ), // OpenCode
+            (
+                Editor::Crush,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                true,
+            ), // Crush
         ];
 
         for f in flags {
             let cmd = Commands::Mcp {
                 cwd: ".".to_string(),
-                init_cursor: f.0,
-                init_vscode: f.1,
-                init_codex: f.2,
-                init_gemini: f.3,
-                init_claude_code: f.4,
-                init_antigravity: f.5,
-                init_cline: f.6,
-                init_opencode: f.7,
-                init_crush: f.8,
+                init_cursor: f.1,
+                init_vscode: f.2,
+                init_codex: f.3,
+                init_gemini: f.4,
+                init_claude_code: f.5,
+                init_antigravity: f.6,
+                init_cline: f.7,
+                init_opencode: f.8,
+                init_crush: f.9,
             };
+
+            let expected_path = f.0.config_path();
+            if expected_path.exists() {
+                let _ = std::fs::remove_file(&expected_path);
+            }
+
             let result = run_command(cmd).await;
             assert!(result.is_ok());
+
+            assert!(
+                expected_path.exists(),
+                "Config path {:?} was not generated for {:?}",
+                expected_path,
+                f.0
+            );
+
+            // Clean up config file to ensure test isolation
+            let _ = std::fs::remove_file(&expected_path);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,10 @@ enum Commands {
         /// Generate ~/.claude-code/settings.json for Claude Code
         #[arg(long)]
         init_claude_code: bool,
+
+        /// Generate ~/.gemini/antigravity-ide/mcp_config.json for Antigravity
+        #[arg(long)]
+        init_antigravity: bool,
     },
 
     /// Initialize dela and configure shell integration
@@ -188,6 +192,7 @@ async fn run_command(command: Commands) -> anyhow::Result<()> {
             init_codex,
             init_gemini,
             init_claude_code,
+            init_antigravity,
         } => {
             commands::mcp::execute(
                 cwd,
@@ -196,6 +201,7 @@ async fn run_command(command: Commands) -> anyhow::Result<()> {
                 init_codex,
                 init_gemini,
                 init_claude_code,
+                init_antigravity,
             )
             .await
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP configuration support for Antigravity, Cline, OpenCode, and Crush.
  * Added CLI flags: `--init-antigravity`, `--init-cline`, `--init-opencode`, `--init-crush`.
* **Documentation**
  * Updated MCP setup instructions to focus on agent setup and added expanded initialization examples for the new editors.
* **Bug Fixes**
  * MCP config generation now uses the resolved `dela` executable path for the `command` field.
  * Improved config merge behavior for existing empty/blank files and clearer handling of conflicting init flags.
* **Tests**
  * Added coverage for single-flag and multi-flag init scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->