### PR TITLE
refactor: reduce complexity in mcp related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ dela mcp --init-cursor       # Cursor: ~/.cursor/mcp.json
 $ dela mcp --init-vscode       # VSCode: ~/.vscode/mcp.json
 $ dela mcp --init-codex        # OpenAI Codex: ~/.codex/config.toml
 $ dela mcp --init-gemini       # Gemini CLI: ~/.gemini/settings.json
-$ dela mcp --init-antigravity  # Antigravity: ~/.gemini/antigravity-ide/mcp_config.json
+$ dela mcp --init-antigravity  # Antigravity: ~/.gemini/config/mcp_config.json
 $ dela mcp --init-claude-code  # Claude Code: ~/.claude-code/settings.json
 $ dela mcp --init-cline        # Cline: ~/.cline/data/settings/cline_mcp_settings.json (override with CLINE_MCP_SETTINGS_PATH)
 $ dela mcp --init-opencode     # OpenCode: ~/.config/opencode/opencode.json

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -3,6 +3,14 @@
   "version": "0.2.0",
   "entries": [
     {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_start",
+      "line": 441,
+      "cyclomatic": 48.0,
+      "coverage": 70.33195020746888,
+      "crap": 108.1657690672513
+    },
+    {
       "file": "./src/commands/list.rs",
       "function": "execute",
       "line": 22,
@@ -11,20 +19,20 @@
       "crap": 93.25000551433072
     },
     {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::task_start",
-      "line": 441,
-      "cyclomatic": 44.0,
-      "coverage": 71.12068965517241,
-      "crap": 90.6300419758908
-    },
-    {
       "file": "./src/prompt.rs",
       "function": "run_tui",
       "line": 148,
       "cyclomatic": 9.0,
       "coverage": 0.0,
       "crap": 90.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::stop_managed_job",
+      "line": 566,
+      "cyclomatic": 16.0,
+      "coverage": 44.44444444444444,
+      "crap": 59.89574759945131
     },
     {
       "file": "./src/prompt.rs",
@@ -37,7 +45,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::garbage_collect",
-      "line": 719,
+      "line": 764,
       "cyclomatic": 8.0,
       "coverage": 22.22222222222222,
       "crap": 38.1124828532236
@@ -45,18 +53,10 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_job",
-      "line": 496,
+      "line": 518,
       "cyclomatic": 5.0,
       "coverage": 0.0,
       "crap": 30.0
-    },
-    {
-      "file": "./src/mcp/job_manager.rs",
-      "function": "JobManager::stop_managed_job",
-      "line": 544,
-      "cyclomatic": 12.0,
-      "coverage": 52.17391304347826,
-      "crap": 27.752773896605575
     },
     {
       "file": "./src/main.rs",
@@ -97,6 +97,14 @@
       "cyclomatic": 21.0,
       "coverage": 100.0,
       "crap": 21.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_output",
+      "line": 1168,
+      "cyclomatic": 16.0,
+      "coverage": 74.19354838709677,
+      "crap": 20.399718035648355
     },
     {
       "file": "./src/task_discovery/turbo.rs",
@@ -177,14 +185,6 @@
       "cyclomatic": 18.0,
       "coverage": 88.0,
       "crap": 18.559872
-    },
-    {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::task_output",
-      "line": 1119,
-      "cyclomatic": 14.0,
-      "coverage": 73.25581395348837,
-      "crap": 17.74924849384331
     },
     {
       "file": "./src/allowlist.rs",
@@ -285,7 +285,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::call_tool",
-      "line": 1345,
+      "line": 1419,
       "cyclomatic": 13.0,
       "coverage": 100.0,
       "crap": 13.0
@@ -305,6 +305,14 @@
       "cyclomatic": 8.0,
       "coverage": 61.111111111111114,
       "crap": 11.764060356652948
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_stop",
+      "line": 1297,
+      "cyclomatic": 8.0,
+      "coverage": 62.71186440677966,
+      "crap": 11.318119184532012
     },
     {
       "file": "./src/parsers/parse_turbo_json.rs",
@@ -419,6 +427,14 @@
       "crap": 9.051008746355684
     },
     {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::update_job_state",
+      "line": 456,
+      "cyclomatic": 6.0,
+      "coverage": 56.25,
+      "crap": 9.0146484375
+    },
+    {
       "file": "./src/parsers/parse_pom_xml.rs",
       "function": "add_plugin_tasks",
       "line": 91,
@@ -499,28 +515,12 @@
       "crap": 7.853884062388863
     },
     {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::task_stop",
-      "line": 1238,
-      "cyclomatic": 7.0,
-      "coverage": 76.74418604651163,
-      "crap": 7.616297936030789
-    },
-    {
-      "file": "./src/mcp/job_manager.rs",
-      "function": "JobManager::update_job_state",
-      "line": 441,
-      "cyclomatic": 5.0,
-      "coverage": 53.333333333333336,
-      "crap": 7.540740740740741
-    },
-    {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::push_line",
-      "line": 83,
+      "line": 88,
       "cyclomatic": 7.0,
-      "coverage": 81.25,
-      "crap": 7.322998046875
+      "coverage": 77.77777777777779,
+      "crap": 7.5377229080932775
     },
     {
       "file": "./src/parsers/parse_github_actions.rs",
@@ -579,6 +579,14 @@
       "crap": 7.0
     },
     {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::get_stats",
+      "line": 816,
+      "cyclomatic": 6.0,
+      "coverage": 83.33333333333334,
+      "crap": 6.166666666666666
+    },
+    {
       "file": "./src/allowlist.rs",
       "function": "save_allowlist",
       "line": 40,
@@ -589,7 +597,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::record_completed_job",
-      "line": 381,
+      "line": 396,
       "cyclomatic": 6.0,
       "coverage": 93.54838709677419,
       "crap": 6.009667349199423
@@ -661,7 +669,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::initialize",
-      "line": 1331,
+      "line": 1405,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -725,7 +733,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_unmanaged_job_fallback",
-      "line": 648,
+      "line": 693,
       "cyclomatic": 4.0,
       "coverage": 54.54545454545454,
       "crap": 5.5026296018031555
@@ -745,14 +753,6 @@
       "cyclomatic": 5.0,
       "coverage": 85.71428571428571,
       "crap": 5.072886297376093
-    },
-    {
-      "file": "./src/mcp/job_manager.rs",
-      "function": "JobManager::get_stats",
-      "line": 771,
-      "cyclomatic": 5.0,
-      "coverage": 88.23529411764706,
-      "crap": 5.0407083248524325
     },
     {
       "file": "./src/config.rs",
@@ -949,7 +949,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::get_output_lines",
-      "line": 249,
+      "line": 264,
       "cyclomatic": 3.0,
       "coverage": 80.0,
       "crap": 3.072
@@ -965,7 +965,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::start_job",
-      "line": 340,
+      "line": 355,
       "cyclomatic": 3.0,
       "coverage": 86.20689655172413,
       "crap": 3.0236172044774285
@@ -981,7 +981,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::remove_job",
-      "line": 703,
+      "line": 748,
       "cyclomatic": 3.0,
       "coverage": 88.88888888888889,
       "crap": 3.0123456790123457
@@ -997,7 +997,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_job_graceful",
-      "line": 519,
+      "line": 541,
       "cyclomatic": 3.0,
       "coverage": 95.0,
       "crap": 3.001125
@@ -1189,7 +1189,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::can_start_job",
-      "line": 326,
+      "line": 341,
       "cyclomatic": 2.0,
       "coverage": 66.66666666666666,
       "crap": 2.1481481481481484
@@ -1221,7 +1221,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::add_job_output_chunk",
-      "line": 479,
+      "line": 501,
       "cyclomatic": 2.0,
       "coverage": 91.66666666666666,
       "crap": 2.002314814814815
@@ -1397,7 +1397,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::get_last_entries",
-      "line": 110,
+      "line": 117,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
@@ -1405,7 +1405,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::is_empty",
-      "line": 161,
+      "line": 168,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1413,7 +1413,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::add_output",
-      "line": 234,
+      "line": 249,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
@@ -1421,7 +1421,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::idle_time",
-      "line": 270,
+      "line": 285,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1461,7 +1461,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::list_tools",
-      "line": 1383,
+      "line": 1457,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1469,7 +1469,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level",
-      "line": 1726,
+      "line": 1800,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1713,6 +1713,14 @@
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_status",
+      "line": 1104,
+      "cyclomatic": 1.0,
+      "coverage": 90.38461538461539,
+      "crap": 1.000888996358671
     },
     {
       "file": "./src/parsers/parse_taskfile.rs",
@@ -2045,7 +2053,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "OutputLine::new",
-      "line": 50,
+      "line": 53,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2053,7 +2061,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "OutputLine::len",
-      "line": 57,
+      "line": 60,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2061,7 +2069,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::new",
-      "line": 73,
+      "line": 77,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2069,7 +2077,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::get_all_entries",
-      "line": 122,
+      "line": 129,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2077,7 +2085,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::get_entries_from",
-      "line": 127,
+      "line": 134,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2085,7 +2093,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::get_last_lines",
-      "line": 138,
+      "line": 145,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2093,7 +2101,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::get_all_lines",
-      "line": 147,
+      "line": 154,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2101,7 +2109,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::len",
-      "line": 155,
+      "line": 162,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2109,7 +2117,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::is_full",
-      "line": 166,
+      "line": 173,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2117,7 +2125,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::capacity",
-      "line": 171,
+      "line": 178,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2125,7 +2133,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "RingBuffer::total_bytes",
-      "line": 176,
+      "line": 183,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2133,7 +2141,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::new",
-      "line": 195,
+      "line": 202,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2141,7 +2149,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::touch",
-      "line": 213,
+      "line": 220,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2149,7 +2157,15 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::mark_exited",
-      "line": 218,
+      "line": 225,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "Job::mark_signaled",
+      "line": 233,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2157,7 +2173,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::mark_failed",
-      "line": 226,
+      "line": 241,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2165,7 +2181,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::get_output_entries_from",
-      "line": 243,
+      "line": 258,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2173,7 +2189,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::is_running",
-      "line": 257,
+      "line": 272,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2181,7 +2197,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "Job::age",
-      "line": 263,
+      "line": 278,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2189,7 +2205,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManagerConfig::default",
-      "line": 288,
+      "line": 303,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2197,7 +2213,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::new",
-      "line": 311,
+      "line": 326,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2205,7 +2221,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::with_config",
-      "line": 316,
+      "line": 331,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2213,7 +2229,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_job",
-      "line": 420,
+      "line": 435,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2221,7 +2237,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_all_jobs",
-      "line": 426,
+      "line": 441,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2229,7 +2245,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_jobs_by_name",
-      "line": 432,
+      "line": 447,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2237,7 +2253,15 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::update_job_exited",
-      "line": 460,
+      "line": 476,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::update_job_signaled",
+      "line": 482,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2245,7 +2269,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::update_job_failed",
-      "line": 466,
+      "line": 488,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2253,7 +2277,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::add_job_output",
-      "line": 474,
+      "line": 496,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2356,16 +2380,8 @@
     },
     {
       "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::task_status",
-      "line": 1076,
-      "cyclomatic": 1.0,
-      "coverage": 100.0,
-      "crap": 1.0
-    },
-    {
-      "file": "./src/mcp/server.rs",
       "function": "parse_tool_args",
-      "line": 1297,
+      "line": 1371,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2373,7 +2389,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::get_info",
-      "line": 1312,
+      "line": 1386,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2381,7 +2397,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1738,
+      "line": 1812,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2389,7 +2405,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1744,
+      "line": 1818,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -3,14 +3,6 @@
   "version": "0.2.0",
   "entries": [
     {
-      "file": "./src/mcp/job_manager.rs",
-      "function": "JobManager::stop_managed_job",
-      "line": 520,
-      "cyclomatic": 21.0,
-      "coverage": 45.0,
-      "crap": 94.37137500000003
-    },
-    {
       "file": "./src/commands/list.rs",
       "function": "execute",
       "line": 22,
@@ -29,7 +21,7 @@
     {
       "file": "./src/prompt.rs",
       "function": "run_tui",
-      "line": 144,
+      "line": 142,
       "cyclomatic": 9.0,
       "coverage": 0.0,
       "crap": 90.0
@@ -45,7 +37,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::garbage_collect",
-      "line": 718,
+      "line": 711,
       "cyclomatic": 8.0,
       "coverage": 22.22222222222222,
       "crap": 38.1124828532236
@@ -53,10 +45,18 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_job",
-      "line": 484,
+      "line": 496,
       "cyclomatic": 5.0,
       "coverage": 0.0,
       "crap": 30.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::stop_managed_job",
+      "line": 537,
+      "cyclomatic": 12.0,
+      "coverage": 53.333333333333336,
+      "crap": 26.634666666666668
     },
     {
       "file": "./src/main.rs",
@@ -275,14 +275,6 @@
       "crap": 13.061588921282798
     },
     {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::call_tool",
-      "line": 1331,
-      "cyclomatic": 13.0,
-      "coverage": 93.75,
-      "crap": 13.041259765625
-    },
-    {
       "file": "./src/parsers/parse_makefile.rs",
       "function": "extract_include_directives_from_str",
       "line": 106,
@@ -291,12 +283,12 @@
       "crap": 13.003336426272876
     },
     {
-      "file": "./src/mcp/job_manager.rs",
-      "function": "JobManager::stop_unmanaged_job_fallback",
-      "line": 640,
-      "cyclomatic": 8.0,
-      "coverage": 57.692307692307686,
-      "crap": 12.846609012289488
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::call_tool",
+      "line": 1343,
+      "cyclomatic": 13.0,
+      "coverage": 100.0,
+      "crap": 13.0
     },
     {
       "file": "./src/parsers/parse_makefile.rs",
@@ -371,14 +363,6 @@
       "crap": 10.1
     },
     {
-      "file": "./src/prompt.rs",
-      "function": "handle_key_code",
-      "line": 114,
-      "cyclomatic": 10.0,
-      "coverage": 94.44444444444444,
-      "crap": 10.017146776406035
-    },
-    {
       "file": "./src/parsers/parse_gradle.rs",
       "function": "extract_custom_tasks",
       "line": 63,
@@ -390,6 +374,14 @@
       "file": "./src/parsers/parse_gradle.rs",
       "function": "extract_task_description",
       "line": 132,
+      "cyclomatic": 10.0,
+      "coverage": 100.0,
+      "crap": 10.0
+    },
+    {
+      "file": "./src/prompt.rs",
+      "function": "handle_key_code",
+      "line": 114,
       "cyclomatic": 10.0,
       "coverage": 100.0,
       "crap": 10.0
@@ -669,7 +661,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::initialize",
-      "line": 1317,
+      "line": 1329,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -731,6 +723,14 @@
       "crap": 6.0
     },
     {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::stop_unmanaged_job_fallback",
+      "line": 640,
+      "cyclomatic": 4.0,
+      "coverage": 54.54545454545454,
+      "crap": 5.5026296018031555
+    },
+    {
       "file": "./src/task_discovery/maven.rs",
       "function": "discover_maven_tasks",
       "line": 15,
@@ -749,7 +749,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_stats",
-      "line": 770,
+      "line": 763,
       "cyclomatic": 5.0,
       "coverage": 88.23529411764706,
       "crap": 5.0407083248524325
@@ -981,7 +981,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::remove_job",
-      "line": 702,
+      "line": 695,
       "cyclomatic": 3.0,
       "coverage": 88.88888888888889,
       "crap": 3.0123456790123457
@@ -1213,7 +1213,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::add_job_output_chunk",
-      "line": 467,
+      "line": 479,
       "cyclomatic": 2.0,
       "coverage": 91.66666666666666,
       "crap": 2.002314814814815
@@ -1421,7 +1421,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_job_graceful",
-      "line": 507,
+      "line": 519,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
@@ -1461,7 +1461,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::list_tools",
-      "line": 1409,
+      "line": 1381,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1469,7 +1469,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level",
-      "line": 1752,
+      "line": 1724,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -2236,8 +2236,24 @@
     },
     {
       "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::update_job_exited",
+      "line": 460,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::update_job_failed",
+      "line": 466,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::add_job_output",
-      "line": 462,
+      "line": 474,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2348,8 +2364,16 @@
     },
     {
       "file": "./src/mcp/server.rs",
+      "function": "parse_tool_args",
+      "line": 1297,
+      "cyclomatic": 1.0,
+      "coverage": 100.0,
+      "crap": 1.0
+    },
+    {
+      "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::get_info",
-      "line": 1298,
+      "line": 1310,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2357,7 +2381,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1764,
+      "line": 1736,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2365,7 +2389,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1770,
+      "line": 1742,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2485,7 +2509,7 @@
     {
       "file": "./src/prompt.rs",
       "function": "ui",
-      "line": 194,
+      "line": 192,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -21,7 +21,7 @@
     {
       "file": "./src/prompt.rs",
       "function": "run_tui",
-      "line": 142,
+      "line": 148,
       "cyclomatic": 9.0,
       "coverage": 0.0,
       "crap": 90.0
@@ -37,7 +37,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::garbage_collect",
-      "line": 711,
+      "line": 719,
       "cyclomatic": 8.0,
       "coverage": 22.22222222222222,
       "crap": 38.1124828532236
@@ -53,10 +53,10 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_managed_job",
-      "line": 537,
+      "line": 544,
       "cyclomatic": 12.0,
-      "coverage": 53.333333333333336,
-      "crap": 26.634666666666668
+      "coverage": 52.17391304347826,
+      "crap": 27.752773896605575
     },
     {
       "file": "./src/main.rs",
@@ -285,7 +285,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::call_tool",
-      "line": 1343,
+      "line": 1345,
       "cyclomatic": 13.0,
       "coverage": 100.0,
       "crap": 13.0
@@ -313,6 +313,14 @@
       "cyclomatic": 7.0,
       "coverage": 55.55555555555556,
       "crap": 11.301783264746227
+    },
+    {
+      "file": "./src/prompt.rs",
+      "function": "handle_key_code",
+      "line": 114,
+      "cyclomatic": 11.0,
+      "coverage": 95.0,
+      "crap": 11.015125
     },
     {
       "file": "./src/commands/run_command.rs",
@@ -374,14 +382,6 @@
       "file": "./src/parsers/parse_gradle.rs",
       "function": "extract_task_description",
       "line": 132,
-      "cyclomatic": 10.0,
-      "coverage": 100.0,
-      "crap": 10.0
-    },
-    {
-      "file": "./src/prompt.rs",
-      "function": "handle_key_code",
-      "line": 114,
       "cyclomatic": 10.0,
       "coverage": 100.0,
       "crap": 10.0
@@ -661,7 +661,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::initialize",
-      "line": 1329,
+      "line": 1331,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -725,7 +725,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_unmanaged_job_fallback",
-      "line": 640,
+      "line": 648,
       "cyclomatic": 4.0,
       "coverage": 54.54545454545454,
       "crap": 5.5026296018031555
@@ -749,7 +749,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_stats",
-      "line": 763,
+      "line": 771,
       "cyclomatic": 5.0,
       "coverage": 88.23529411764706,
       "crap": 5.0407083248524325
@@ -981,7 +981,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::remove_job",
-      "line": 695,
+      "line": 703,
       "cyclomatic": 3.0,
       "coverage": 88.88888888888889,
       "crap": 3.0123456790123457
@@ -993,6 +993,14 @@
       "cyclomatic": 3.0,
       "coverage": 91.66666666666666,
       "crap": 3.0052083333333335
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::stop_job_graceful",
+      "line": 519,
+      "cyclomatic": 3.0,
+      "coverage": 95.0,
+      "crap": 3.001125
     },
     {
       "file": "./src/parsers/parse_taskfile.rs",
@@ -1419,14 +1427,6 @@
       "crap": 2.0
     },
     {
-      "file": "./src/mcp/job_manager.rs",
-      "function": "JobManager::stop_job_graceful",
-      "line": 519,
-      "cyclomatic": 2.0,
-      "coverage": 100.0,
-      "crap": 2.0
-    },
-    {
       "file": "./src/mcp/server.rs",
       "function": "OutputNotificationBatch::add_line",
       "line": 86,
@@ -1461,7 +1461,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::list_tools",
-      "line": 1381,
+      "line": 1383,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1469,7 +1469,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level",
-      "line": 1724,
+      "line": 1726,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -2373,7 +2373,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::get_info",
-      "line": 1310,
+      "line": 1312,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2381,7 +2381,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1736,
+      "line": 1738,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2389,7 +2389,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1742,
+      "line": 1744,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2509,7 +2509,7 @@
     {
       "file": "./src/prompt.rs",
       "function": "ui",
-      "line": 192,
+      "line": 198,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -3,14 +3,6 @@
   "version": "0.2.0",
   "entries": [
     {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::task_start",
-      "line": 441,
-      "cyclomatic": 48.0,
-      "coverage": 70.33195020746888,
-      "crap": 108.1657690672513
-    },
-    {
       "file": "./src/commands/list.rs",
       "function": "execute",
       "line": 22,
@@ -29,10 +21,18 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_managed_job",
-      "line": 566,
+      "line": 568,
       "cyclomatic": 16.0,
       "coverage": 44.44444444444444,
       "crap": 59.89574759945131
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::task_start",
+      "line": 649,
+      "cyclomatic": 38.0,
+      "coverage": 75.80645161290323,
+      "crap": 58.44870934174748
     },
     {
       "file": "./src/prompt.rs",
@@ -45,7 +45,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::garbage_collect",
-      "line": 764,
+      "line": 766,
       "cyclomatic": 8.0,
       "coverage": 22.22222222222222,
       "crap": 38.1124828532236
@@ -53,7 +53,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_job",
-      "line": 518,
+      "line": 520,
       "cyclomatic": 5.0,
       "coverage": 0.0,
       "crap": 30.0
@@ -101,10 +101,10 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_output",
-      "line": 1168,
+      "line": 1073,
       "cyclomatic": 16.0,
-      "coverage": 74.19354838709677,
-      "crap": 20.399718035648355
+      "coverage": 73.40425531914893,
+      "crap": 20.81588857960183
     },
     {
       "file": "./src/task_discovery/turbo.rs",
@@ -285,7 +285,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::call_tool",
-      "line": 1419,
+      "line": 1325,
       "cyclomatic": 13.0,
       "coverage": 100.0,
       "crap": 13.0
@@ -309,7 +309,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_stop",
-      "line": 1297,
+      "line": 1203,
       "cyclomatic": 8.0,
       "coverage": 62.71186440677966,
       "crap": 11.318119184532012
@@ -371,6 +371,14 @@
       "crap": 10.885645167903563
     },
     {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::run_background_monitoring",
+      "line": 524,
+      "cyclomatic": 7.0,
+      "coverage": 59.55056179775281,
+      "crap": 10.242900042413211
+    },
+    {
       "file": "./src/prompt.rs",
       "function": "prompt_for_task_fallback",
       "line": 68,
@@ -429,7 +437,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::update_job_state",
-      "line": 456,
+      "line": 460,
       "cyclomatic": 6.0,
       "coverage": 56.25,
       "crap": 9.0146484375
@@ -581,7 +589,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_stats",
-      "line": 816,
+      "line": 818,
       "cyclomatic": 6.0,
       "coverage": 83.33333333333334,
       "crap": 6.166666666666666
@@ -669,7 +677,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::initialize",
-      "line": 1405,
+      "line": 1311,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -733,7 +741,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_unmanaged_job_fallback",
-      "line": 693,
+      "line": 695,
       "cyclomatic": 4.0,
       "coverage": 54.54545454545454,
       "crap": 5.5026296018031555
@@ -761,6 +769,14 @@
       "cyclomatic": 5.0,
       "coverage": 90.9090909090909,
       "crap": 5.018782870022539
+    },
+    {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::run_initial_capture",
+      "line": 438,
+      "cyclomatic": 5.0,
+      "coverage": 91.66666666666666,
+      "crap": 5.014467592592593
     },
     {
       "file": "./src/task_discovery/turbo.rs",
@@ -981,7 +997,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::remove_job",
-      "line": 748,
+      "line": 750,
       "cyclomatic": 3.0,
       "coverage": 88.88888888888889,
       "crap": 3.0123456790123457
@@ -997,7 +1013,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::stop_job_graceful",
-      "line": 541,
+      "line": 543,
       "cyclomatic": 3.0,
       "coverage": 95.0,
       "crap": 3.001125
@@ -1221,7 +1237,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::add_job_output_chunk",
-      "line": 501,
+      "line": 503,
       "cyclomatic": 2.0,
       "coverage": 91.66666666666666,
       "crap": 2.002314814814815
@@ -1461,7 +1477,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::list_tools",
-      "line": 1457,
+      "line": 1363,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1469,7 +1485,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level",
-      "line": 1800,
+      "line": 1706,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1717,7 +1733,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_status",
-      "line": 1104,
+      "line": 1009,
       "cyclomatic": 1.0,
       "coverage": 90.38461538461539,
       "crap": 1.000888996358671
@@ -2229,7 +2245,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_job",
-      "line": 435,
+      "line": 439,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2237,7 +2253,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_all_jobs",
-      "line": 441,
+      "line": 445,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2245,7 +2261,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_jobs_by_name",
-      "line": 447,
+      "line": 451,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2253,7 +2269,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::update_job_exited",
-      "line": 476,
+      "line": 480,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2261,7 +2277,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::update_job_signaled",
-      "line": 482,
+      "line": 486,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2269,7 +2285,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::update_job_failed",
-      "line": 488,
+      "line": 490,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2277,7 +2293,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::add_job_output",
-      "line": 496,
+      "line": 498,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2381,7 +2397,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "parse_tool_args",
-      "line": 1371,
+      "line": 1277,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2389,7 +2405,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::get_info",
-      "line": 1386,
+      "line": 1292,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2397,7 +2413,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1812,
+      "line": 1718,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2405,7 +2421,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1818,
+      "line": 1724,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0

--- a/cargo_crap_baseline.json
+++ b/cargo_crap_baseline.json
@@ -4,27 +4,11 @@
   "entries": [
     {
       "file": "./src/mcp/job_manager.rs",
-      "function": "JobManager::stop_job_graceful",
-      "line": 507,
-      "cyclomatic": 29.0,
-      "coverage": 24.691358024691358,
-      "crap": 388.19513360843445
-    },
-    {
-      "file": "./src/mcp/server.rs",
-      "function": "DelaMcpServer::call_tool",
-      "line": 1330,
-      "cyclomatic": 13.0,
-      "coverage": 0.0,
-      "crap": 182.0
-    },
-    {
-      "file": "./src/prompt.rs",
-      "function": "run_tui",
-      "line": 106,
-      "cyclomatic": 13.0,
-      "coverage": 0.0,
-      "crap": 182.0
+      "function": "JobManager::stop_managed_job",
+      "line": 520,
+      "cyclomatic": 21.0,
+      "coverage": 45.0,
+      "crap": 94.37137500000003
     },
     {
       "file": "./src/commands/list.rs",
@@ -37,10 +21,18 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_start",
-      "line": 440,
+      "line": 441,
       "cyclomatic": 44.0,
       "coverage": 71.12068965517241,
       "crap": 90.6300419758908
+    },
+    {
+      "file": "./src/prompt.rs",
+      "function": "run_tui",
+      "line": 144,
+      "cyclomatic": 9.0,
+      "coverage": 0.0,
+      "crap": 90.0
     },
     {
       "file": "./src/prompt.rs",
@@ -53,7 +45,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::garbage_collect",
-      "line": 701,
+      "line": 718,
       "cyclomatic": 8.0,
       "coverage": 22.22222222222222,
       "crap": 38.1124828532236
@@ -189,7 +181,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_output",
-      "line": 1118,
+      "line": 1119,
       "cyclomatic": 14.0,
       "coverage": 73.25581395348837,
       "crap": 17.74924849384331
@@ -223,8 +215,8 @@
       "function": "evaluate_task_against_allowlist",
       "line": 75,
       "cyclomatic": 17.0,
-      "coverage": 100.0,
-      "crap": 17.0
+      "coverage": 96.42857142857143,
+      "crap": 17.013165087463555
     },
     {
       "file": "./src/commands/allow_command.rs",
@@ -283,12 +275,28 @@
       "crap": 13.061588921282798
     },
     {
+      "file": "./src/mcp/server.rs",
+      "function": "DelaMcpServer::call_tool",
+      "line": 1331,
+      "cyclomatic": 13.0,
+      "coverage": 93.75,
+      "crap": 13.041259765625
+    },
+    {
       "file": "./src/parsers/parse_makefile.rs",
       "function": "extract_include_directives_from_str",
       "line": 106,
       "cyclomatic": 13.0,
       "coverage": 97.2972972972973,
       "crap": 13.003336426272876
+    },
+    {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::stop_unmanaged_job_fallback",
+      "line": 640,
+      "cyclomatic": 8.0,
+      "coverage": 57.692307692307686,
+      "crap": 12.846609012289488
     },
     {
       "file": "./src/parsers/parse_makefile.rs",
@@ -361,6 +369,14 @@
       "cyclomatic": 10.0,
       "coverage": 90.0,
       "crap": 10.1
+    },
+    {
+      "file": "./src/prompt.rs",
+      "function": "handle_key_code",
+      "line": 114,
+      "cyclomatic": 10.0,
+      "coverage": 94.44444444444444,
+      "crap": 10.017146776406035
     },
     {
       "file": "./src/parsers/parse_gradle.rs",
@@ -493,7 +509,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_stop",
-      "line": 1237,
+      "line": 1238,
       "cyclomatic": 7.0,
       "coverage": 76.74418604651163,
       "crap": 7.616297936030789
@@ -629,7 +645,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::add_job_output_chunks",
-      "line": 220,
+      "line": 221,
       "cyclomatic": 6.0,
       "coverage": 100.0,
       "crap": 6.0
@@ -637,7 +653,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::send_task_output",
-      "line": 306,
+      "line": 307,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -645,7 +661,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::serve_stdio",
-      "line": 364,
+      "line": 365,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -653,7 +669,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::initialize",
-      "line": 1316,
+      "line": 1317,
       "cyclomatic": 2.0,
       "coverage": 0.0,
       "crap": 6.0
@@ -733,7 +749,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::get_stats",
-      "line": 753,
+      "line": 770,
       "cyclomatic": 5.0,
       "coverage": 88.23529411764706,
       "crap": 5.0407083248524325
@@ -925,7 +941,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::resolve_wait_for_exit_seconds",
-      "line": 286,
+      "line": 287,
       "cyclomatic": 4.0,
       "coverage": 100.0,
       "crap": 4.0
@@ -941,7 +957,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::send_log",
-      "line": 201,
+      "line": 202,
       "cyclomatic": 2.0,
       "coverage": 36.36363636363637,
       "crap": 3.0308039068369643
@@ -965,7 +981,7 @@
     {
       "file": "./src/mcp/job_manager.rs",
       "function": "JobManager::remove_job",
-      "line": 685,
+      "line": 702,
       "cyclomatic": 3.0,
       "coverage": 88.88888888888889,
       "crap": 3.0123456790123457
@@ -1061,7 +1077,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::append_output_chunk",
-      "line": 213,
+      "line": 214,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0
@@ -1069,7 +1085,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::get_discovered_tasks",
-      "line": 343,
+      "line": 344,
       "cyclomatic": 3.0,
       "coverage": 100.0,
       "crap": 3.0
@@ -1157,7 +1173,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::flush_output_notification_batch",
-      "line": 259,
+      "line": 260,
       "cyclomatic": 2.0,
       "coverage": 58.82352941176471,
       "crap": 2.2792591084876856
@@ -1403,6 +1419,14 @@
       "crap": 2.0
     },
     {
+      "file": "./src/mcp/job_manager.rs",
+      "function": "JobManager::stop_job_graceful",
+      "line": 507,
+      "cyclomatic": 2.0,
+      "coverage": 100.0,
+      "crap": 2.0
+    },
+    {
       "file": "./src/mcp/server.rs",
       "function": "OutputNotificationBatch::add_line",
       "line": 86,
@@ -1421,7 +1445,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::truncate_output_entry_for_chunk",
-      "line": 250,
+      "line": 251,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
@@ -1429,7 +1453,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::list_tasks",
-      "line": 382,
+      "line": 383,
       "cyclomatic": 2.0,
       "coverage": 100.0,
       "crap": 2.0
@@ -1437,7 +1461,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::list_tools",
-      "line": 1408,
+      "line": 1409,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -1445,7 +1469,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level",
-      "line": 1751,
+      "line": 1752,
       "cyclomatic": 1.0,
       "coverage": 0.0,
       "crap": 2.0
@@ -2245,7 +2269,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::new",
-      "line": 161,
+      "line": 162,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2253,7 +2277,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::new_inner",
-      "line": 169,
+      "line": 170,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2261,7 +2285,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::new_with_allowlist",
-      "line": 187,
+      "line": 188,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2269,7 +2293,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::new_with_allowlist_and_cache_ttl",
-      "line": 192,
+      "line": 193,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2277,7 +2301,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::output_entries_to_json",
-      "line": 240,
+      "line": 241,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2285,7 +2309,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::output_flush_timer_deadline",
-      "line": 279,
+      "line": 280,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2293,7 +2317,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::send_task_event",
-      "line": 324,
+      "line": 325,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2301,7 +2325,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::root",
-      "line": 339,
+      "line": 340,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2309,7 +2333,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::status",
-      "line": 409,
+      "line": 410,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2317,7 +2341,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::task_status",
-      "line": 1075,
+      "line": 1076,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2325,7 +2349,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::get_info",
-      "line": 1297,
+      "line": 1298,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2333,7 +2357,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1763,
+      "line": 1764,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2341,7 +2365,7 @@
     {
       "file": "./src/mcp/server.rs",
       "function": "DelaMcpServer::set_level_impl",
-      "line": 1769,
+      "line": 1770,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0
@@ -2461,7 +2485,7 @@
     {
       "file": "./src/prompt.rs",
       "function": "ui",
-      "line": 169,
+      "line": 194,
       "cyclomatic": 1.0,
       "coverage": 100.0,
       "crap": 1.0

--- a/src/commands/mcp.rs
+++ b/src/commands/mcp.rs
@@ -48,7 +48,7 @@ impl Editor {
             Editor::Codex => home.join(".codex/config.toml"),
             Editor::Gemini => home.join(".gemini/settings.json"),
             Editor::ClaudeCode => home.join(".claude-code/settings.json"),
-            Editor::Antigravity => home.join(".gemini/antigravity-ide/mcp_config.json"),
+            Editor::Antigravity => home.join(".gemini/config/mcp_config.json"),
             Editor::Cline => std::env::var("CLINE_MCP_SETTINGS_PATH")
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| home.join(".cline/data/settings/cline_mcp_settings.json")),
@@ -475,7 +475,7 @@ mod tests {
         );
         assert_eq!(
             Editor::Antigravity.config_path(),
-            home.join(".gemini/antigravity-ide/mcp_config.json")
+            home.join(".gemini/config/mcp_config.json")
         );
         assert_eq!(
             Editor::Cline.config_path(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ enum Commands {
         #[arg(long)]
         init_claude_code: bool,
 
-        /// Generate ~/.gemini/antigravity-ide/mcp_config.json for Antigravity
+        /// Generate ~/.gemini/config/mcp_config.json for Antigravity
         #[arg(long)]
         init_antigravity: bool,
 

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -653,16 +653,20 @@ impl OutputChunkDto {
 /// Result of starting a task
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct StartResultDto {
-    /// Current state of the task: "exited", "running", or "failed"
+    /// Current state of the task: "exited", "running", "failed", or "signaled"
     pub state: String,
 
-    /// Process ID if the task is running
+    /// Process ID if the task is running or just finished
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<i32>,
 
-    /// Exit code if the task has exited
+    /// Exit code if the task has exited normally
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
+
+    /// Signal number if the task was terminated by a signal
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal: Option<i32>,
 
     /// Output chunks captured before returning, preserving stream identity.
     pub output: Vec<OutputChunkDto>,

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -529,6 +529,13 @@ impl JobManager {
             self.stop_managed_job(pid, process, grace_period_seconds)
                 .await
         } else {
+            let is_tracked = {
+                let jobs = self.jobs.read().await;
+                jobs.contains_key(&pid)
+            };
+            if !is_tracked {
+                return Err(anyhow::anyhow!("Job with PID {} not found", pid));
+            }
             self.stop_unmanaged_job_fallback(pid, grace_period_seconds)
                 .await
         }
@@ -610,8 +617,9 @@ impl JobManager {
                             Ok(StopResult::Forced)
                         }
                         Err(nix::errno::Errno::ESRCH) => {
-                            self.update_job_exited(pid, 0).await;
-                            Ok(StopResult::Graceful(0))
+                            let exit_status = process.wait().await.ok().and_then(|s| s.code()).unwrap_or(0);
+                            self.update_job_exited(pid, exit_status).await;
+                            Ok(StopResult::Graceful(exit_status))
                         }
                         Err(e) => {
                             self.update_job_failed(pid, format!("Failed to send SIGKILL: {}", e))
@@ -1136,7 +1144,15 @@ mod tests {
     async fn test_stop_job_graceful_fallback() {
         let manager = JobManager::new();
 
-        let pid = 999999;
+        let mut child = tokio::process::Command::new("true")
+            .spawn()
+            .unwrap();
+        let pid = child.id().unwrap();
+        
+        // Wait for it to exit so it's fully reaped and no longer a zombie.
+        // This gives us a safe PID that is guaranteed to be dead and return ESRCH.
+        let _ = child.wait().await;
+
         let metadata = JobMetadata {
             started_at: Instant::now(),
             unique_name: "test-fallback".to_string(),
@@ -1144,7 +1160,7 @@ mod tests {
             args: None,
             env: None,
             cwd: None,
-            command: "nonexistent".to_string(),
+            command: "sleep 10".to_string(),
             file_path: PathBuf::from("Makefile"),
         };
 
@@ -1166,6 +1182,9 @@ mod tests {
             let job = manager.get_job(pid).await.unwrap();
             assert!(matches!(job.state, JobState::Failed(_)));
         }
+
+        let _ = child.kill().await;
+        let _ = child.wait().await;
     }
 
     #[tokio::test]

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -1237,11 +1237,20 @@ mod tests {
     async fn test_stop_job_graceful_managed_sigkill() {
         let manager = JobManager::new();
 
-        let mut cmd = Command::new("python3");
-        cmd.arg("-c");
-        cmd.arg(
-            "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(10)",
-        );
+        #[cfg(unix)]
+        let mut cmd = {
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c");
+            cmd.arg("trap '' TERM; sleep 10");
+            cmd
+        };
+        #[cfg(not(unix))]
+        let mut cmd = {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/c");
+            cmd.arg("ping 127.0.0.1 -n 10");
+            cmd
+        };
         let child = cmd.spawn().unwrap();
         let pid = child.id().unwrap();
 

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -408,7 +408,9 @@ impl JobManager {
         }
         let elapsed_at_completion = match state {
             JobState::Running => None,
-            JobState::Exited(_) | JobState::Failed(_) | JobState::Signaled(_) => Some(metadata.started_at.elapsed()),
+            JobState::Exited(_) | JobState::Failed(_) | JobState::Signaled(_) => {
+                Some(metadata.started_at.elapsed())
+            }
         };
         jobs.insert(
             pid,
@@ -417,7 +419,9 @@ impl JobManager {
                 metadata,
                 completed_at: match state {
                     JobState::Running => None,
-                    JobState::Exited(_) | JobState::Failed(_) | JobState::Signaled(_) => Some(Utc::now()),
+                    JobState::Exited(_) | JobState::Failed(_) | JobState::Signaled(_) => {
+                        Some(Utc::now())
+                    }
                 },
                 elapsed_at_completion,
                 state,
@@ -480,9 +484,7 @@ impl JobManager {
     }
 
     async fn update_job_signaled(&self, pid: u32, signal: i32) {
-        let _ = self
-            .update_job_state(pid, JobState::Signaled(signal))
-            .await;
+        let _ = self.update_job_state(pid, JobState::Signaled(signal)).await;
     }
 
     async fn update_job_failed(&self, pid: u32, error_message: String) {
@@ -1190,11 +1192,9 @@ mod tests {
     async fn test_stop_job_graceful_fallback() {
         let manager = JobManager::new();
 
-        let mut child = tokio::process::Command::new("true")
-            .spawn()
-            .unwrap();
+        let mut child = tokio::process::Command::new("true").spawn().unwrap();
         let pid = child.id().unwrap();
-        
+
         // Wait for it to exit so it's fully reaped and no longer a zombie.
         // This gives us a safe PID that is guaranteed to be dead and return ESRCH.
         let _ = child.wait().await;

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -509,176 +509,193 @@ impl JobManager {
         pid: u32,
         grace_period_seconds: u64,
     ) -> anyhow::Result<StopResult> {
+        let mut processes = self.processes.write().await;
+        if let Some(process) = processes.remove(&pid) {
+            self.stop_managed_job(pid, process, grace_period_seconds).await
+        } else {
+            self.stop_unmanaged_job_fallback(pid, grace_period_seconds).await
+        }
+    }
+
+    async fn stop_managed_job(
+        &self,
+        pid: u32,
+        mut process: Child,
+        grace_period_seconds: u64,
+    ) -> anyhow::Result<StopResult> {
         use tokio::time::{Duration, timeout};
 
-        // First, try to get the process from our managed processes
-        let mut processes = self.processes.write().await;
-        if let Some(mut process) = processes.remove(&pid) {
-            #[cfg(unix)]
-            {
-                use nix::sys::signal::{self, Signal};
-                use nix::unistd::Pid;
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{self, Signal};
+            use nix::unistd::Pid;
 
-                match signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
-                    Ok(()) => {}
-                    Err(nix::errno::Errno::ESRCH) => {
-                        let exit_status = process.wait().await.map_err(|e| {
-                            anyhow::anyhow!("Process already exited but wait failed: {}", e)
-                        })?;
-                        let exit_code = exit_status.code().unwrap_or(0);
-                        let mut jobs = self.jobs.write().await;
-                        if let Some(job) = jobs.get_mut(&pid) {
-                            job.mark_exited(exit_code);
-                        }
-                        return Ok(StopResult::Graceful(exit_code));
-                    }
-                    Err(e) => {
-                        let mut jobs = self.jobs.write().await;
-                        if let Some(job) = jobs.get_mut(&pid) {
-                            job.mark_failed(format!("Failed to send SIGTERM: {}", e));
-                        }
-                        return Ok(StopResult::Failed(format!("Failed to send SIGTERM: {}", e)));
-                    }
-                }
-            }
-            #[cfg(not(unix))]
-            {
-                if let Err(e) = process.kill().await {
-                    let mut jobs = self.jobs.write().await;
-                    if let Some(job) = jobs.get_mut(&pid) {
-                        job.mark_failed(format!("Failed to stop process: {}", e));
-                    }
-                    return Ok(StopResult::Failed(format!("Failed to stop process: {}", e)));
-                }
-            }
-
-            // Wait for the process to exit gracefully
-            let grace_duration = Duration::from_secs(grace_period_seconds);
-            let wait_result = timeout(grace_duration, process.wait()).await;
-
-            match wait_result {
-                Ok(Ok(exit_status)) => {
-                    // Process exited gracefully
-                    let exit_code = exit_status.code().unwrap_or(-1);
+            match signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
+                Ok(()) => {}
+                Err(nix::errno::Errno::ESRCH) => {
+                    let exit_status = process.wait().await.map_err(|e| {
+                        anyhow::anyhow!("Process already exited but wait failed: {}", e)
+                    })?;
+                    let exit_code = exit_status.code().unwrap_or(0);
                     let mut jobs = self.jobs.write().await;
                     if let Some(job) = jobs.get_mut(&pid) {
                         job.mark_exited(exit_code);
                     }
-                    Ok(StopResult::Graceful(exit_code))
+                    return Ok(StopResult::Graceful(exit_code));
                 }
-                Ok(Err(e)) => {
-                    // Process wait failed
+                Err(e) => {
                     let mut jobs = self.jobs.write().await;
                     if let Some(job) = jobs.get_mut(&pid) {
-                        job.mark_failed(format!("Process wait failed: {}", e));
+                        job.mark_failed(format!("Failed to send SIGTERM: {}", e));
                     }
-                    Ok(StopResult::Failed(format!("Process wait failed: {}", e)))
-                }
-                Err(_) => {
-                    // Grace period expired, send SIGKILL
-                    #[cfg(unix)]
-                    {
-                        use nix::sys::signal::{self, Signal};
-                        use nix::unistd::Pid;
-
-                        let result = signal::kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
-                        match result {
-                            Ok(()) => {
-                                // Update job state to stopped
-                                let mut jobs = self.jobs.write().await;
-                                if let Some(job) = jobs.get_mut(&pid) {
-                                    job.mark_failed(
-                                        "Stopped with SIGKILL after grace period".to_string(),
-                                    );
-                                }
-                                Ok(StopResult::Forced)
-                            }
-                            Err(nix::errno::Errno::ESRCH) => {
-                                // Process already exited - this is actually success
-                                let mut jobs = self.jobs.write().await;
-                                if let Some(job) = jobs.get_mut(&pid) {
-                                    job.mark_exited(0); // Process already exited gracefully
-                                }
-                                Ok(StopResult::Graceful(0)) // Treat as graceful exit
-                            }
-                            Err(e) => {
-                                // Other signal errors
-                                let mut jobs = self.jobs.write().await;
-                                if let Some(job) = jobs.get_mut(&pid) {
-                                    job.mark_failed(format!("Failed to send SIGKILL: {}", e));
-                                }
-                                Ok(StopResult::Failed(format!("Failed to send SIGKILL: {}", e)))
-                            }
-                        }
-                    }
-                    #[cfg(not(unix))]
-                    {
-                        // On non-Unix systems, we can't send signals, so just mark as failed
-                        let mut jobs = self.jobs.write().await;
-                        if let Some(job) = jobs.get_mut(&pid) {
-                            job.mark_failed("SIGKILL not supported on this platform".to_string());
-                        }
-                        Ok(StopResult::Failed(
-                            "SIGKILL not supported on this platform".to_string(),
-                        ))
-                    }
+                    return Ok(StopResult::Failed(format!("Failed to send SIGTERM: {}", e)));
                 }
             }
-        } else {
-            // Fallback: no Child handle (likely already moved to monitor). Use PID signals.
-            #[cfg(unix)]
-            {
-                use nix::sys::signal::{self, Signal};
-                use nix::unistd::Pid;
-
-                // Send SIGTERM best-effort
-                let _ = signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
-
-                // Wait for grace period
-                tokio::time::sleep(Duration::from_secs(grace_period_seconds)).await;
-
-                // Send SIGKILL if still present
-                let kill_result = signal::kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
-
-                match kill_result {
-                    Ok(()) => {
-                        // Mark job as forced stop
-                        let mut jobs = self.jobs.write().await;
-                        if let Some(job) = jobs.get_mut(&pid) {
-                            job.mark_failed("Stopped with SIGKILL (fallback)".to_string());
-                        }
-                        Ok(StopResult::Forced)
-                    }
-                    Err(nix::errno::Errno::ESRCH) => {
-                        // Process already exited - this is actually success
-                        let mut jobs = self.jobs.write().await;
-                        if let Some(job) = jobs.get_mut(&pid) {
-                            job.mark_exited(0); // Process already exited gracefully
-                        }
-                        Ok(StopResult::Graceful(0)) // Treat as graceful exit
-                    }
-                    Err(e) => {
-                        let mut jobs = self.jobs.write().await;
-                        if let Some(job) = jobs.get_mut(&pid) {
-                            job.mark_failed(format!("Failed to send SIGKILL (fallback): {}", e));
-                        }
-                        Ok(StopResult::Failed(format!("Failed to send SIGKILL: {}", e)))
-                    }
-                }
-            }
-            #[cfg(not(unix))]
-            {
-                // On non-Unix systems, we can't send signals, so just mark as failed
+        }
+        #[cfg(not(unix))]
+        {
+            if let Err(e) = process.kill().await {
                 let mut jobs = self.jobs.write().await;
                 if let Some(job) = jobs.get_mut(&pid) {
-                    job.mark_failed("Signal handling not supported on this platform".to_string());
+                    job.mark_failed(format!("Failed to stop process: {}", e));
                 }
-                Ok(StopResult::Failed(
-                    "Signal handling not supported on this platform".to_string(),
-                ))
+                return Ok(StopResult::Failed(format!("Failed to stop process: {}", e)));
+            }
+        }
+
+        // Wait for the process to exit gracefully
+        let grace_duration = Duration::from_secs(grace_period_seconds);
+        let wait_result = timeout(grace_duration, process.wait()).await;
+
+        match wait_result {
+            Ok(Ok(exit_status)) => {
+                // Process exited gracefully
+                let exit_code = exit_status.code().unwrap_or(-1);
+                let mut jobs = self.jobs.write().await;
+                if let Some(job) = jobs.get_mut(&pid) {
+                    job.mark_exited(exit_code);
+                }
+                Ok(StopResult::Graceful(exit_code))
+            }
+            Ok(Err(e)) => {
+                // Process wait failed
+                let mut jobs = self.jobs.write().await;
+                if let Some(job) = jobs.get_mut(&pid) {
+                    job.mark_failed(format!("Process wait failed: {}", e));
+                }
+                Ok(StopResult::Failed(format!("Process wait failed: {}", e)))
+            }
+            Err(_) => {
+                // Grace period expired, send SIGKILL
+                #[cfg(unix)]
+                {
+                    use nix::sys::signal::{self, Signal};
+                    use nix::unistd::Pid;
+
+                    let result = signal::kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
+                    match result {
+                        Ok(()) => {
+                            // Update job state to stopped
+                            let mut jobs = self.jobs.write().await;
+                            if let Some(job) = jobs.get_mut(&pid) {
+                                job.mark_failed(
+                                    "Stopped with SIGKILL after grace period".to_string(),
+                                );
+                            }
+                            Ok(StopResult::Forced)
+                        }
+                        Err(nix::errno::Errno::ESRCH) => {
+                            // Process already exited - this is actually success
+                            let mut jobs = self.jobs.write().await;
+                            if let Some(job) = jobs.get_mut(&pid) {
+                                job.mark_exited(0); // Process already exited gracefully
+                            }
+                            Ok(StopResult::Graceful(0)) // Treat as graceful exit
+                        }
+                        Err(e) => {
+                            // Other signal errors
+                            let mut jobs = self.jobs.write().await;
+                            if let Some(job) = jobs.get_mut(&pid) {
+                                job.mark_failed(format!("Failed to send SIGKILL: {}", e));
+                            }
+                            Ok(StopResult::Failed(format!("Failed to send SIGKILL: {}", e)))
+                        }
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    // On non-Unix systems, we can't send signals, so just mark as failed
+                    let mut jobs = self.jobs.write().await;
+                    if let Some(job) = jobs.get_mut(&pid) {
+                        job.mark_failed("SIGKILL not supported on this platform".to_string());
+                    }
+                    Ok(StopResult::Failed(
+                        "SIGKILL not supported on this platform".to_string(),
+                    ))
+                }
             }
         }
     }
+
+    async fn stop_unmanaged_job_fallback(
+        &self,
+        pid: u32,
+        grace_period_seconds: u64,
+    ) -> anyhow::Result<StopResult> {
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{self, Signal};
+            use nix::unistd::Pid;
+            use tokio::time::Duration;
+
+            // Send SIGTERM best-effort
+            let _ = signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+
+            // Wait for grace period
+            tokio::time::sleep(Duration::from_secs(grace_period_seconds)).await;
+
+            // Send SIGKILL if still present
+            let kill_result = signal::kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
+
+            match kill_result {
+                Ok(()) => {
+                    // Mark job as forced stop
+                    let mut jobs = self.jobs.write().await;
+                    if let Some(job) = jobs.get_mut(&pid) {
+                        job.mark_failed("Stopped with SIGKILL (fallback)".to_string());
+                    }
+                    Ok(StopResult::Forced)
+                }
+                Err(nix::errno::Errno::ESRCH) => {
+                    // Process already exited - this is actually success
+                    let mut jobs = self.jobs.write().await;
+                    if let Some(job) = jobs.get_mut(&pid) {
+                        job.mark_exited(0); // Process already exited gracefully
+                    }
+                    Ok(StopResult::Graceful(0)) // Treat as graceful exit
+                }
+                Err(e) => {
+                    let mut jobs = self.jobs.write().await;
+                    if let Some(job) = jobs.get_mut(&pid) {
+                        job.mark_failed(format!("Failed to send SIGKILL (fallback): {}", e));
+                    }
+                    Ok(StopResult::Failed(format!("Failed to send SIGKILL: {}", e)))
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            // On non-Unix systems, we can't send signals, so just mark as failed
+            let mut jobs = self.jobs.write().await;
+            if let Some(job) = jobs.get_mut(&pid) {
+                job.mark_failed("Signal handling not supported on this platform".to_string());
+            }
+            Ok(StopResult::Failed(
+                "Signal handling not supported on this platform".to_string(),
+            ))
+        }
+    }
+
 
     /// Remove a job
     #[allow(dead_code)]
@@ -1085,5 +1102,129 @@ mod tests {
         assert!(job.is_running());
 
         let _ = manager.stop_job_graceful(pid, 0).await;
+    }
+
+    #[tokio::test]
+    async fn test_stop_job_graceful_managed_success() {
+        let manager = JobManager::new();
+
+        let mut cmd = Command::new("sleep");
+        cmd.arg("10");
+        let child = cmd.spawn().unwrap();
+        let pid = child.id().unwrap();
+
+        let metadata = JobMetadata {
+            started_at: Instant::now(),
+            unique_name: "test-sleep".to_string(),
+            source_name: "test".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            command: "sleep 10".to_string(),
+            file_path: PathBuf::from("Makefile"),
+        };
+
+        manager.start_job(pid, metadata, child).await.unwrap();
+
+        let stop_result = manager.stop_job_graceful(pid, 1).await.unwrap();
+        assert!(matches!(
+            stop_result,
+            StopResult::Graceful(_) | StopResult::Forced
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_stop_job_graceful_fallback() {
+        let manager = JobManager::new();
+
+        let pid = 999999;
+        let metadata = JobMetadata {
+            started_at: Instant::now(),
+            unique_name: "test-fallback".to_string(),
+            source_name: "test".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            command: "nonexistent".to_string(),
+            file_path: PathBuf::from("Makefile"),
+        };
+
+        {
+            let mut jobs = manager.jobs.write().await;
+            jobs.insert(
+                pid,
+                Job::new(
+                    pid,
+                    metadata,
+                    10,
+                    1000,
+                ),
+            );
+        }
+
+        let stop_result = manager.stop_job_graceful(pid, 1).await.unwrap();
+        #[cfg(unix)]
+        assert_eq!(stop_result, StopResult::Graceful(0));
+        #[cfg(not(unix))]
+        assert!(matches!(stop_result, StopResult::Failed(_)));
+    }
+
+    #[tokio::test]
+    async fn test_stop_job_graceful_managed_sigkill() {
+        let manager = JobManager::new();
+
+        let mut cmd = Command::new("python3");
+        cmd.arg("-c");
+        cmd.arg("import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(10)");
+        let child = cmd.spawn().unwrap();
+        let pid = child.id().unwrap();
+
+        let metadata = JobMetadata {
+            started_at: Instant::now(),
+            unique_name: "test-sigkill".to_string(),
+            source_name: "test".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            command: "ignore term".to_string(),
+            file_path: PathBuf::from("Makefile"),
+        };
+
+        manager.start_job(pid, metadata, child).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let stop_result = manager.stop_job_graceful(pid, 1).await.unwrap();
+        #[cfg(unix)]
+        assert_eq!(stop_result, StopResult::Forced);
+        #[cfg(not(unix))]
+        assert!(matches!(stop_result, StopResult::Failed(_) | StopResult::Graceful(_)));
+    }
+
+    #[tokio::test]
+    async fn test_stop_job_graceful_already_exited() {
+        let manager = JobManager::new();
+
+        let mut cmd = Command::new("echo");
+        let child = cmd.spawn().unwrap();
+        let pid = child.id().unwrap();
+
+        let metadata = JobMetadata {
+            started_at: Instant::now(),
+            unique_name: "test-exited".to_string(),
+            source_name: "test".to_string(),
+            args: None,
+            env: None,
+            cwd: None,
+            command: "echo".to_string(),
+            file_path: PathBuf::from("Makefile"),
+        };
+
+        manager.start_job(pid, metadata, child).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let stop_result = manager.stop_job_graceful(pid, 1).await.unwrap();
+        assert!(matches!(stop_result, StopResult::Graceful(_)));
     }
 }

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -457,6 +457,18 @@ impl JobManager {
         }
     }
 
+    async fn update_job_exited(&self, pid: u32, exit_code: i32) {
+        let _ = self
+            .update_job_state(pid, JobState::Exited(exit_code))
+            .await;
+    }
+
+    async fn update_job_failed(&self, pid: u32, error_message: String) {
+        let _ = self
+            .update_job_state(pid, JobState::Failed(error_message))
+            .await;
+    }
+
     /// Add stdout output to a job for tests that do not care about stream identity.
     #[cfg(test)]
     pub async fn add_job_output(&self, pid: u32, output: String) -> anyhow::Result<()> {
@@ -509,11 +521,16 @@ impl JobManager {
         pid: u32,
         grace_period_seconds: u64,
     ) -> anyhow::Result<StopResult> {
-        let mut processes = self.processes.write().await;
-        if let Some(process) = processes.remove(&pid) {
-            self.stop_managed_job(pid, process, grace_period_seconds).await
+        let maybe_process = {
+            let mut processes = self.processes.write().await;
+            processes.remove(&pid)
+        };
+        if let Some(process) = maybe_process {
+            self.stop_managed_job(pid, process, grace_period_seconds)
+                .await
         } else {
-            self.stop_unmanaged_job_fallback(pid, grace_period_seconds).await
+            self.stop_unmanaged_job_fallback(pid, grace_period_seconds)
+                .await
         }
     }
 
@@ -537,17 +554,12 @@ impl JobManager {
                         anyhow::anyhow!("Process already exited but wait failed: {}", e)
                     })?;
                     let exit_code = exit_status.code().unwrap_or(0);
-                    let mut jobs = self.jobs.write().await;
-                    if let Some(job) = jobs.get_mut(&pid) {
-                        job.mark_exited(exit_code);
-                    }
+                    self.update_job_exited(pid, exit_code).await;
                     return Ok(StopResult::Graceful(exit_code));
                 }
                 Err(e) => {
-                    let mut jobs = self.jobs.write().await;
-                    if let Some(job) = jobs.get_mut(&pid) {
-                        job.mark_failed(format!("Failed to send SIGTERM: {}", e));
-                    }
+                    self.update_job_failed(pid, format!("Failed to send SIGTERM: {}", e))
+                        .await;
                     return Ok(StopResult::Failed(format!("Failed to send SIGTERM: {}", e)));
                 }
             }
@@ -555,10 +567,8 @@ impl JobManager {
         #[cfg(not(unix))]
         {
             if let Err(e) = process.kill().await {
-                let mut jobs = self.jobs.write().await;
-                if let Some(job) = jobs.get_mut(&pid) {
-                    job.mark_failed(format!("Failed to stop process: {}", e));
-                }
+                self.update_job_failed(pid, format!("Failed to stop process: {}", e))
+                    .await;
                 return Ok(StopResult::Failed(format!("Failed to stop process: {}", e)));
             }
         }
@@ -571,18 +581,13 @@ impl JobManager {
             Ok(Ok(exit_status)) => {
                 // Process exited gracefully
                 let exit_code = exit_status.code().unwrap_or(-1);
-                let mut jobs = self.jobs.write().await;
-                if let Some(job) = jobs.get_mut(&pid) {
-                    job.mark_exited(exit_code);
-                }
+                self.update_job_exited(pid, exit_code).await;
                 Ok(StopResult::Graceful(exit_code))
             }
             Ok(Err(e)) => {
                 // Process wait failed
-                let mut jobs = self.jobs.write().await;
-                if let Some(job) = jobs.get_mut(&pid) {
-                    job.mark_failed(format!("Process wait failed: {}", e));
-                }
+                self.update_job_failed(pid, format!("Process wait failed: {}", e))
+                    .await;
                 Ok(StopResult::Failed(format!("Process wait failed: {}", e)))
             }
             Err(_) => {
@@ -595,40 +600,35 @@ impl JobManager {
                     let result = signal::kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
                     match result {
                         Ok(()) => {
-                            // Update job state to stopped
-                            let mut jobs = self.jobs.write().await;
-                            if let Some(job) = jobs.get_mut(&pid) {
-                                job.mark_failed(
-                                    "Stopped with SIGKILL after grace period".to_string(),
-                                );
-                            }
+                            // Wait/reap the child process to prevent zombie processes
+                            let _ = process.wait().await;
+                            self.update_job_failed(
+                                pid,
+                                "Stopped with SIGKILL after grace period".to_string(),
+                            )
+                            .await;
                             Ok(StopResult::Forced)
                         }
                         Err(nix::errno::Errno::ESRCH) => {
-                            // Process already exited - this is actually success
-                            let mut jobs = self.jobs.write().await;
-                            if let Some(job) = jobs.get_mut(&pid) {
-                                job.mark_exited(0); // Process already exited gracefully
-                            }
-                            Ok(StopResult::Graceful(0)) // Treat as graceful exit
+                            self.update_job_exited(pid, 0).await;
+                            Ok(StopResult::Graceful(0))
                         }
                         Err(e) => {
-                            // Other signal errors
-                            let mut jobs = self.jobs.write().await;
-                            if let Some(job) = jobs.get_mut(&pid) {
-                                job.mark_failed(format!("Failed to send SIGKILL: {}", e));
-                            }
+                            self.update_job_failed(pid, format!("Failed to send SIGKILL: {}", e))
+                                .await;
                             Ok(StopResult::Failed(format!("Failed to send SIGKILL: {}", e)))
                         }
                     }
                 }
                 #[cfg(not(unix))]
                 {
-                    // On non-Unix systems, we can't send signals, so just mark as failed
-                    let mut jobs = self.jobs.write().await;
-                    if let Some(job) = jobs.get_mut(&pid) {
-                        job.mark_failed("SIGKILL not supported on this platform".to_string());
-                    }
+                    let _ = process.kill().await;
+                    let _ = process.wait().await;
+                    self.update_job_failed(
+                        pid,
+                        "SIGKILL not supported on this platform".to_string(),
+                    )
+                    .await;
                     Ok(StopResult::Failed(
                         "SIGKILL not supported on this platform".to_string(),
                     ))
@@ -659,43 +659,36 @@ impl JobManager {
 
             match kill_result {
                 Ok(()) => {
-                    // Mark job as forced stop
-                    let mut jobs = self.jobs.write().await;
-                    if let Some(job) = jobs.get_mut(&pid) {
-                        job.mark_failed("Stopped with SIGKILL (fallback)".to_string());
-                    }
+                    self.update_job_failed(pid, "Stopped with SIGKILL (fallback)".to_string())
+                        .await;
                     Ok(StopResult::Forced)
                 }
                 Err(nix::errno::Errno::ESRCH) => {
-                    // Process already exited - this is actually success
-                    let mut jobs = self.jobs.write().await;
-                    if let Some(job) = jobs.get_mut(&pid) {
-                        job.mark_exited(0); // Process already exited gracefully
-                    }
-                    Ok(StopResult::Graceful(0)) // Treat as graceful exit
+                    self.update_job_exited(pid, 0).await;
+                    Ok(StopResult::Graceful(0))
                 }
                 Err(e) => {
-                    let mut jobs = self.jobs.write().await;
-                    if let Some(job) = jobs.get_mut(&pid) {
-                        job.mark_failed(format!("Failed to send SIGKILL (fallback): {}", e));
-                    }
+                    self.update_job_failed(
+                        pid,
+                        format!("Failed to send SIGKILL (fallback): {}", e),
+                    )
+                    .await;
                     Ok(StopResult::Failed(format!("Failed to send SIGKILL: {}", e)))
                 }
             }
         }
         #[cfg(not(unix))]
         {
-            // On non-Unix systems, we can't send signals, so just mark as failed
-            let mut jobs = self.jobs.write().await;
-            if let Some(job) = jobs.get_mut(&pid) {
-                job.mark_failed("Signal handling not supported on this platform".to_string());
-            }
+            self.update_job_failed(
+                pid,
+                "Signal handling not supported on this platform".to_string(),
+            )
+            .await;
             Ok(StopResult::Failed(
                 "Signal handling not supported on this platform".to_string(),
             ))
         }
     }
-
 
     /// Remove a job
     #[allow(dead_code)]
@@ -1131,6 +1124,12 @@ mod tests {
             stop_result,
             StopResult::Graceful(_) | StopResult::Forced
         ));
+        let job = manager.get_job(pid).await.unwrap();
+        assert!(!job.is_running());
+        assert!(matches!(
+            job.state,
+            JobState::Exited(_) | JobState::Failed(_)
+        ));
     }
 
     #[tokio::test]
@@ -1151,22 +1150,22 @@ mod tests {
 
         {
             let mut jobs = manager.jobs.write().await;
-            jobs.insert(
-                pid,
-                Job::new(
-                    pid,
-                    metadata,
-                    10,
-                    1000,
-                ),
-            );
+            jobs.insert(pid, Job::new(pid, metadata, 10, 1000));
         }
 
         let stop_result = manager.stop_job_graceful(pid, 1).await.unwrap();
         #[cfg(unix)]
-        assert_eq!(stop_result, StopResult::Graceful(0));
+        {
+            assert_eq!(stop_result, StopResult::Graceful(0));
+            let job = manager.get_job(pid).await.unwrap();
+            assert_eq!(job.state, JobState::Exited(0));
+        }
         #[cfg(not(unix))]
-        assert!(matches!(stop_result, StopResult::Failed(_)));
+        {
+            assert!(matches!(stop_result, StopResult::Failed(_)));
+            let job = manager.get_job(pid).await.unwrap();
+            assert!(matches!(job.state, JobState::Failed(_)));
+        }
     }
 
     #[tokio::test]
@@ -1175,7 +1174,9 @@ mod tests {
 
         let mut cmd = Command::new("python3");
         cmd.arg("-c");
-        cmd.arg("import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(10)");
+        cmd.arg(
+            "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(10)",
+        );
         let child = cmd.spawn().unwrap();
         let pid = child.id().unwrap();
 
@@ -1196,9 +1197,20 @@ mod tests {
 
         let stop_result = manager.stop_job_graceful(pid, 1).await.unwrap();
         #[cfg(unix)]
-        assert_eq!(stop_result, StopResult::Forced);
+        {
+            assert_eq!(stop_result, StopResult::Forced);
+            let job = manager.get_job(pid).await.unwrap();
+            assert!(matches!(job.state, JobState::Failed(_)));
+        }
         #[cfg(not(unix))]
-        assert!(matches!(stop_result, StopResult::Failed(_) | StopResult::Graceful(_)));
+        {
+            assert!(matches!(
+                stop_result,
+                StopResult::Failed(_) | StopResult::Graceful(_)
+            ));
+            let job = manager.get_job(pid).await.unwrap();
+            assert!(!job.is_running());
+        }
     }
 
     #[tokio::test]
@@ -1226,5 +1238,7 @@ mod tests {
 
         let stop_result = manager.stop_job_graceful(pid, 1).await.unwrap();
         assert!(matches!(stop_result, StopResult::Graceful(_)));
+        let job = manager.get_job(pid).await.unwrap();
+        assert!(!job.is_running());
     }
 }

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -11,6 +11,8 @@ use tokio::sync::RwLock;
 pub enum StopResult {
     /// Process stopped gracefully with exit code
     Graceful(i32),
+    /// Process stopped by signal
+    Signaled(i32),
     /// Process was force-killed after grace period
     Forced,
     /// Stop operation failed
@@ -22,6 +24,7 @@ pub enum StopResult {
 pub enum JobState {
     Running,
     Exited(i32),    // exit code
+    Signaled(i32),  // signal number
     Failed(String), // error message
 }
 
@@ -66,6 +69,7 @@ pub struct RingBuffer {
     max_size: usize,
     total_bytes: usize,
     max_bytes: usize,
+    pub dropped_lines: usize,
 }
 
 impl RingBuffer {
@@ -76,6 +80,7 @@ impl RingBuffer {
             max_size: max_lines,
             total_bytes: 0,
             max_bytes,
+            dropped_lines: 0,
         }
     }
 
@@ -88,6 +93,7 @@ impl RingBuffer {
         while self.buffer.len() >= self.max_size {
             if let Some(removed) = self.buffer.pop_front() {
                 self.total_bytes = self.total_bytes.saturating_sub(removed.len());
+                self.dropped_lines += 1;
             }
         }
 
@@ -95,6 +101,7 @@ impl RingBuffer {
         while self.total_bytes + line_bytes > self.max_bytes && !self.buffer.is_empty() {
             if let Some(removed) = self.buffer.pop_front() {
                 self.total_bytes = self.total_bytes.saturating_sub(removed.len());
+                self.dropped_lines += 1;
             }
         }
 
@@ -218,6 +225,14 @@ impl Job {
     pub fn mark_exited(&mut self, exit_code: i32) {
         self.elapsed_at_completion = Some(self.metadata.started_at.elapsed());
         self.state = JobState::Exited(exit_code);
+        self.completed_at = Some(Utc::now());
+        self.touch();
+    }
+
+    /// Mark the job as exited by a signal
+    pub fn mark_signaled(&mut self, signal: i32) {
+        self.elapsed_at_completion = Some(self.metadata.started_at.elapsed());
+        self.state = JobState::Signaled(signal);
         self.completed_at = Some(Utc::now());
         self.touch();
     }
@@ -393,7 +408,7 @@ impl JobManager {
         }
         let elapsed_at_completion = match state {
             JobState::Running => None,
-            JobState::Exited(_) | JobState::Failed(_) => Some(metadata.started_at.elapsed()),
+            JobState::Exited(_) | JobState::Failed(_) | JobState::Signaled(_) => Some(metadata.started_at.elapsed()),
         };
         jobs.insert(
             pid,
@@ -402,7 +417,7 @@ impl JobManager {
                 metadata,
                 completed_at: match state {
                     JobState::Running => None,
-                    JobState::Exited(_) | JobState::Failed(_) => Some(Utc::now()),
+                    JobState::Exited(_) | JobState::Failed(_) | JobState::Signaled(_) => Some(Utc::now()),
                 },
                 elapsed_at_completion,
                 state,
@@ -449,6 +464,7 @@ impl JobManager {
                     job.touch();
                 }
                 JobState::Exited(exit_code) => job.mark_exited(exit_code),
+                JobState::Signaled(signal) => job.mark_signaled(signal),
                 JobState::Failed(error) => job.mark_failed(error),
             }
             Ok(())
@@ -460,6 +476,12 @@ impl JobManager {
     async fn update_job_exited(&self, pid: u32, exit_code: i32) {
         let _ = self
             .update_job_state(pid, JobState::Exited(exit_code))
+            .await;
+    }
+
+    async fn update_job_signaled(&self, pid: u32, signal: i32) {
+        let _ = self
+            .update_job_state(pid, JobState::Signaled(signal))
             .await;
     }
 
@@ -560,6 +582,11 @@ impl JobManager {
                     let exit_status = process.wait().await.map_err(|e| {
                         anyhow::anyhow!("Process already exited but wait failed: {}", e)
                     })?;
+                    use std::os::unix::process::ExitStatusExt;
+                    if let Some(sig) = exit_status.signal() {
+                        self.update_job_signaled(pid, sig).await;
+                        return Ok(StopResult::Signaled(sig));
+                    }
                     let exit_code = exit_status.code().unwrap_or(0);
                     self.update_job_exited(pid, exit_code).await;
                     return Ok(StopResult::Graceful(exit_code));
@@ -587,6 +614,14 @@ impl JobManager {
         match wait_result {
             Ok(Ok(exit_status)) => {
                 // Process exited gracefully
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    if let Some(sig) = exit_status.signal() {
+                        self.update_job_signaled(pid, sig).await;
+                        return Ok(StopResult::Signaled(sig));
+                    }
+                }
                 let exit_code = exit_status.code().unwrap_or(-1);
                 self.update_job_exited(pid, exit_code).await;
                 Ok(StopResult::Graceful(exit_code))
@@ -617,9 +652,19 @@ impl JobManager {
                             Ok(StopResult::Forced)
                         }
                         Err(nix::errno::Errno::ESRCH) => {
-                            let exit_status = process.wait().await.ok().and_then(|s| s.code()).unwrap_or(0);
-                            self.update_job_exited(pid, exit_status).await;
-                            Ok(StopResult::Graceful(exit_status))
+                            let exit_status = process.wait().await.ok();
+                            if let Some(status) = exit_status {
+                                use std::os::unix::process::ExitStatusExt;
+                                if let Some(sig) = status.signal() {
+                                    self.update_job_signaled(pid, sig).await;
+                                    return Ok(StopResult::Signaled(sig));
+                                }
+                                let code = status.code().unwrap_or(0);
+                                self.update_job_exited(pid, code).await;
+                                return Ok(StopResult::Graceful(code));
+                            }
+                            self.update_job_exited(pid, 0).await;
+                            Ok(StopResult::Graceful(0))
                         }
                         Err(e) => {
                             self.update_job_failed(pid, format!("Failed to send SIGKILL: {}", e))
@@ -778,6 +823,7 @@ impl JobManager {
             match job.state {
                 JobState::Running => running += 1,
                 JobState::Exited(_) => exited += 1,
+                JobState::Signaled(_) => exited += 1, // Treat signaled as exited for summary
                 JobState::Failed(_) => failed += 1,
             }
         }
@@ -1130,13 +1176,13 @@ mod tests {
         let stop_result = manager.stop_job_graceful(pid, 1).await.unwrap();
         assert!(matches!(
             stop_result,
-            StopResult::Graceful(_) | StopResult::Forced
+            StopResult::Graceful(_) | StopResult::Forced | StopResult::Signaled(_)
         ));
         let job = manager.get_job(pid).await.unwrap();
         assert!(!job.is_running());
         assert!(matches!(
             job.state,
-            JobState::Exited(_) | JobState::Failed(_)
+            JobState::Exited(_) | JobState::Failed(_) | JobState::Signaled(_)
         ));
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -772,11 +772,10 @@ impl DelaMcpServer {
             let exit_status = child.wait().await.map_err(|e| {
                 DelaError::internal_error(
                     format!("Failed to wait for process: {}", e),
-                    Some("Process may have terminated unexpectedly".to_string()),
+                    Some("Process management error".to_string()),
                 )
             })?;
 
-            let exit_code = exit_status.code();
             let output_chunks = captured_output_chunks.lock().await.clone();
 
             // Wait for reader tasks to finish
@@ -799,9 +798,20 @@ impl DelaMcpServer {
                 file_path: task.definition_path().to_path_buf(),
             };
 
-            let exit_state = JobState::Exited(exit_code.unwrap_or(-1));
+            let mut exit_code = exit_status.code();
+            let mut signal = None;
+            let mut exit_state = JobState::Exited(exit_code.unwrap_or(-1));
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                if let Some(sig) = exit_status.signal() {
+                    signal = Some(sig);
+                    exit_code = None;
+                    exit_state = JobState::Signaled(sig);
+                }
+            }
             self.job_manager
-                .record_completed_job(pid as u32, metadata, exit_state)
+                .record_completed_job(pid as u32, metadata, exit_state.clone())
                 .await
                 .map_err(|e| {
                     DelaError::internal_error(
@@ -834,9 +844,13 @@ impl DelaMcpServer {
             .await;
 
             let start_result = StartResultDto {
-                state: "exited".to_string(),
-                pid: None,
+                state: match exit_state {
+                    JobState::Signaled(_) => "signaled".to_string(),
+                    _ => "exited".to_string(),
+                },
+                pid: Some(pid as i32),
                 exit_code,
+                signal,
                 output: output_chunks,
             };
 
@@ -1029,13 +1043,25 @@ impl DelaMcpServer {
             // Wait for process to exit
             if let Some(mut process) = job_manager.processes.write().await.remove(&pid_u32) {
                 let exit_result = process.wait().await;
-                let (state, exit_code) = match exit_result {
+                let (state, exit_code, signal) = match exit_result {
                     Ok(status) => {
-                        let code = status.code().unwrap_or(-1);
-                        (JobState::Exited(code), Some(code))
+                        let mut state = JobState::Exited(status.code().unwrap_or(-1));
+                        let mut exit_code = status.code();
+                        let mut signal = None;
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::process::ExitStatusExt;
+                            if let Some(sig) = status.signal() {
+                                state = JobState::Signaled(sig);
+                                signal = Some(sig);
+                                exit_code = None;
+                            }
+                        }
+                        (state, exit_code, signal)
                     }
                     Err(e) => (
                         JobState::Failed(format!("Process wait failed: {}", e)),
+                        None,
                         None,
                     ),
                 };
@@ -1052,6 +1078,7 @@ impl DelaMcpServer {
                                 "event": "exited",
                                 "pid": pid_u32,
                                 "exit_code": exit_code,
+                                "signal": signal,
                                 "task": task_name
                             }),
                         })
@@ -1062,8 +1089,9 @@ impl DelaMcpServer {
 
         let start_result = StartResultDto {
             state: "running".to_string(),
-            pid: Some(pid),
+            pid: Some(pid as i32),
             exit_code: None,
+            signal: None,
             output: output_chunks,
         };
 
@@ -1081,13 +1109,32 @@ impl DelaMcpServer {
         let job_statuses: Vec<serde_json::Value> = jobs
             .into_iter()
             .map(|job| {
-                let (state, exit_code) = match &job.state {
-                    JobState::Running => ("running", None),
-                    JobState::Exited(code) => ("exited", Some(*code)),
-                    JobState::Failed(_) => ("failed", None),
-                };
-                let completed_at = job
-                    .completed_at
+                let mut status = "running";
+                let mut exit_code = None;
+                let mut signal = None;
+                let mut completed_at = None;
+                let mut error = None;
+
+                match &job.state {
+                    JobState::Running => {}
+                    JobState::Exited(code) => {
+                        status = "exited";
+                        exit_code = Some(*code);
+                        completed_at = job.completed_at;
+                    }
+                    JobState::Signaled(sig) => {
+                        status = "signaled";
+                        signal = Some(*sig);
+                        completed_at = job.completed_at;
+                    }
+                    JobState::Failed(msg) => {
+                        status = "failed";
+                        error = Some(msg.clone());
+                        completed_at = job.completed_at;
+                    }
+                }
+
+                let completed_at_str = completed_at
                     .as_ref()
                     .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Secs, true));
 
@@ -1095,10 +1142,12 @@ impl DelaMcpServer {
                     "pid": job.pid,
                     "unique_name": job.metadata.unique_name,
                     "source_name": job.metadata.source_name,
-                    "state": state,
-                    "elapsed_seconds": job.age().as_secs(),
+                    "state": status,
+                    "error": error,
                     "exit_code": exit_code,
-                    "completed_at": completed_at,
+                    "signal": signal,
+                    "elapsed_seconds": job.age().as_secs(),
+                    "completed_at": completed_at_str,
                     "command": job.metadata.command,
                     "file_path": job.metadata.file_path.to_string_lossy(),
                     "args": job.metadata.args,
@@ -1138,8 +1187,11 @@ impl DelaMcpServer {
         let output = Self::output_entries_to_json(&output_entries);
         let total_bytes = job.output_buffer.total_bytes();
 
+        let has_more = next_offset < total_lines;
+        let dropped_lines = job.output_buffer.dropped_lines;
+
         let buffer_full = job.output_buffer.is_full();
-        let is_truncated = offset > 0 || next_offset < total_lines || buffer_full;
+        let is_truncated = has_more || dropped_lines > 0 || buffer_full;
 
         // Apply per-message chunk size limit (8KB default)
         const MAX_CHUNK_SIZE: usize = 8 * 1024; // 8KB
@@ -1150,9 +1202,16 @@ impl DelaMcpServer {
             "next_offset": next_offset,
             "total_lines": total_lines,
             "total_bytes": total_bytes,
-            "truncated": is_truncated,
-            "buffer_full": buffer_full
+            "buffer_full": buffer_full,
         });
+
+        if has_more {
+            response["has_more_lines"] = serde_json::Value::Bool(true);
+        }
+        
+        if dropped_lines > 0 {
+            response["dropped_lines"] = serde_json::Value::Number(serde_json::Number::from(dropped_lines));
+        }
 
         // Add truncation details if requested
         if args.show_truncation.unwrap_or(false) {
@@ -1268,18 +1327,31 @@ impl DelaMcpServer {
             })?;
 
         // Determine the response based on how the job was stopped
-        let (status, message) = match stop_result {
-            crate::mcp::job_manager::StopResult::Graceful(exit_code) => (
+        let (status, message, exit_code, signal) = match stop_result {
+            crate::mcp::job_manager::StopResult::Graceful(code) => (
                 "graceful",
-                format!("Process stopped gracefully with exit code {}", exit_code),
+                format!("Process stopped gracefully with exit code {}", code),
+                Some(code),
+                None,
+            ),
+            crate::mcp::job_manager::StopResult::Signaled(sig) => (
+                "signaled",
+                format!("Process stopped by signal {}", sig),
+                None,
+                Some(sig),
             ),
             crate::mcp::job_manager::StopResult::Forced => (
                 "killed",
                 "Process was force-killed after grace period".to_string(),
+                None,
+                None,
             ),
-            crate::mcp::job_manager::StopResult::Failed(reason) => {
-                ("failed", format!("Failed to stop process: {}", reason))
-            }
+            crate::mcp::job_manager::StopResult::Failed(reason) => (
+                "failed",
+                format!("Failed to stop process: {}", reason),
+                None,
+                None,
+            ),
         };
 
         Ok(CallToolResult::success(vec![
@@ -1287,6 +1359,8 @@ impl DelaMcpServer {
                 "pid": args.pid,
                 "status": status,
                 "message": message,
+                "exit_code": exit_code,
+                "signal": signal,
                 "grace_period_used": grace_period
             }))
             .expect("Failed to serialize JSON"),
@@ -2194,7 +2268,7 @@ mod tests {
                 assert_eq!(obj["next_offset"], 4);
                 assert_eq!(obj["total_lines"], 4);
                 assert!(obj["total_bytes"].is_number());
-                assert_eq!(obj["truncated"], true); // We requested 2 lines but have 4
+                assert!(obj.get("has_more_lines").is_none()); // We requested 2 lines out of 4, so offset is 2 and next_offset is 4 == total_lines
                 assert!(obj["buffer_full"].is_boolean());
                 let output = obj["output"].as_array().unwrap();
                 assert_eq!(output.len(), 2);
@@ -2266,14 +2340,14 @@ mod tests {
                 assert_eq!(obj["offset"], 2);
                 assert_eq!(obj["next_offset"], 5);
                 assert_eq!(obj["total_lines"], 5);
-                assert_eq!(obj["truncated"], true);
+                assert!(obj.get("has_more_lines").is_none());
 
                 // Check truncation info is present
                 assert!(obj.contains_key("truncation_info"));
                 let truncation_info = &obj["truncation_info"];
                 assert_eq!(truncation_info["requested_lines"], 3);
                 assert_eq!(truncation_info["returned_lines"], 3);
-                assert_eq!(truncation_info["is_truncated"], true);
+                assert_eq!(truncation_info["is_truncated"], false);
                 assert!(truncation_info["buffer_capacity"].is_number());
             }
             _ => panic!("Expected text content with JSON"),
@@ -2340,7 +2414,7 @@ mod tests {
                 assert_eq!(obj["offset"], 1);
                 assert_eq!(obj["next_offset"], 3);
                 assert_eq!(obj["total_lines"], 5);
-                assert_eq!(obj["truncated"], true);
+                assert_eq!(obj["has_more_lines"], true);
                 assert_eq!(obj["truncation_info"]["returned_lines"], 2);
             }
             _ => panic!("Expected text content with JSON"),
@@ -2409,7 +2483,7 @@ mod tests {
                 assert_eq!(obj["offset"], 0);
                 assert_eq!(obj["next_offset"], 2);
                 assert_eq!(obj["total_lines"], 2);
-                assert_eq!(obj["truncated"], false); // No truncation since we have fewer lines than requested
+                assert!(obj.get("has_more_lines").is_none()); // No truncation since we have fewer lines than requested
 
                 // Check truncation info is present
                 assert!(obj.contains_key("truncation_info"));
@@ -3529,7 +3603,7 @@ add_custom_target(build-all COMMENT "Build everything")
 
         assert_eq!(json["state"], "exited");
         assert_eq!(json["exit_code"], 0);
-        assert!(json.get("pid").is_none());
+        assert!(json.get("pid").is_some());
         let output_chunks = json["output"].as_array().unwrap();
         assert!(output_chunks.iter().any(|chunk| {
             chunk

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1298,11 +1298,13 @@ fn parse_tool_args<T: serde::de::DeserializeOwned>(
     arguments: Option<serde_json::Map<String, serde_json::Value>>,
 ) -> Result<T, ErrorData> {
     serde_json::from_value(serde_json::Value::Object(arguments.unwrap_or_default())).map_err(|e| {
-        DelaError::internal_error(
-            format!("Invalid arguments: {}", e),
-            Some("Check argument format and types".to_string()),
-        )
-        .into()
+        ErrorData {
+            code: super::errors::DelaErrorCode::INVALID_PARAMS.into(),
+            message: std::borrow::Cow::Owned(format!("Invalid arguments: {}", e)),
+            data: Some(serde_json::Value::String(
+                "Check argument format and types".to_string(),
+            )),
+        }
     })
 }
 
@@ -4264,7 +4266,7 @@ add_custom_target(build-all COMMENT "Build everything")
         let res = server.call_tool(req, context).await;
         assert!(res.is_err());
         let err = res.unwrap_err();
-        assert_eq!(err.code.0, -32603);
+        assert_eq!(err.code.0, -32602);
         assert!(err.message.contains("Invalid arguments"));
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1294,6 +1294,18 @@ impl DelaMcpServer {
     }
 }
 
+fn parse_tool_args<T: serde::de::DeserializeOwned>(
+    arguments: Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<T, ErrorData> {
+    serde_json::from_value(serde_json::Value::Object(arguments.unwrap_or_default())).map_err(|e| {
+        DelaError::internal_error(
+            format!("Invalid arguments: {}", e),
+            Some("Check argument format and types".to_string()),
+        )
+        .into()
+    })
+}
+
 impl ServerHandler for DelaMcpServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(
@@ -1335,15 +1347,7 @@ impl ServerHandler for DelaMcpServer {
     ) -> Result<CallToolResult, ErrorData> {
         match request.name.as_ref() {
             "list_tasks" => {
-                let args: ListTasksArgs = serde_json::from_value(serde_json::Value::Object(
-                    request.arguments.unwrap_or_default(),
-                ))
-                .map_err(|e| {
-                    DelaError::internal_error(
-                        format!("Invalid arguments: {}", e),
-                        Some("Check argument format and types".to_string()),
-                    )
-                })?;
+                let args: ListTasksArgs = parse_tool_args(request.arguments)?;
                 self.list_tasks(Parameters(args)).await
             }
             "status" => {
@@ -1351,51 +1355,19 @@ impl ServerHandler for DelaMcpServer {
                 self.status().await
             }
             "task_start" => {
-                let args: TaskStartArgs = serde_json::from_value(serde_json::Value::Object(
-                    request.arguments.unwrap_or_default(),
-                ))
-                .map_err(|e| {
-                    DelaError::internal_error(
-                        format!("Invalid arguments: {}", e),
-                        Some("Check argument format and types".to_string()),
-                    )
-                })?;
+                let args: TaskStartArgs = parse_tool_args(request.arguments)?;
                 self.task_start(Parameters(args)).await
             }
             "task_status" => {
-                let args: TaskStatusArgs = serde_json::from_value(serde_json::Value::Object(
-                    request.arguments.unwrap_or_default(),
-                ))
-                .map_err(|e| {
-                    DelaError::internal_error(
-                        format!("Invalid arguments: {}", e),
-                        Some("Check argument format and types".to_string()),
-                    )
-                })?;
+                let args: TaskStatusArgs = parse_tool_args(request.arguments)?;
                 self.task_status(Parameters(args)).await
             }
             "task_output" => {
-                let args: TaskOutputArgs = serde_json::from_value(serde_json::Value::Object(
-                    request.arguments.unwrap_or_default(),
-                ))
-                .map_err(|e| {
-                    DelaError::internal_error(
-                        format!("Invalid arguments: {}", e),
-                        Some("Check argument format and types".to_string()),
-                    )
-                })?;
+                let args: TaskOutputArgs = parse_tool_args(request.arguments)?;
                 self.task_output(Parameters(args)).await
             }
             "task_stop" => {
-                let args: TaskStopArgs = serde_json::from_value(serde_json::Value::Object(
-                    request.arguments.unwrap_or_default(),
-                ))
-                .map_err(|e| {
-                    DelaError::internal_error(
-                        format!("Invalid arguments: {}", e),
-                        Some("Check argument format and types".to_string()),
-                    )
-                })?;
+                let args: TaskStopArgs = parse_tool_args(request.arguments)?;
                 self.task_stop(Parameters(args)).await
             }
             _ => Err(DelaError::internal_error(
@@ -4279,85 +4251,123 @@ add_custom_target(build-all COMMENT "Build everything")
     }
 
     #[tokio::test]
-    async fn test_call_tool_all_cases() {
-        let temp_dir = std::env::temp_dir();
-        let server = DelaMcpServer::new(temp_dir);
-
+    async fn test_call_tool_invalid_args() {
+        let server = DelaMcpServer::new(std::env::temp_dir());
         let (server_transport, _client_transport) = tokio::io::duplex(4096);
         let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
-        let peer = running_server.peer().clone();
+        let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
 
-        let context = RequestContext::new(RequestId::Number(1), peer);
+        let mut invalid_args = serde_json::Map::new();
+        invalid_args.insert("runner".to_string(), serde_json::Value::Bool(true));
+        let req = CallToolRequestParams::new("list_tasks").with_arguments(invalid_args);
 
-        // 1. Test status (no arguments)
-        let req = CallToolRequestParams::new("status");
-        let res = server.call_tool(req, context.clone()).await;
-        assert!(res.is_ok());
-
-        // 2. Test invalid tool name
-        let req = CallToolRequestParams::new("invalid_tool_name");
-        let res = server.call_tool(req, context.clone()).await;
+        let res = server.call_tool(req, context).await;
         assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert_eq!(err.code.0, -32603);
+        assert!(err.message.contains("Invalid arguments"));
+    }
 
-        // 3. Test list_tasks (empty arguments is ok)
+    #[tokio::test]
+    async fn test_call_tool_unknown_tool() {
+        let server = DelaMcpServer::new(std::env::temp_dir());
+        let (server_transport, _client_transport) = tokio::io::duplex(4096);
+        let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
+        let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
+
+        let req = CallToolRequestParams::new("nonexistent_tool");
+        let res = server.call_tool(req, context).await;
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert_eq!(err.code.0, -32603);
+        assert!(err.message.contains("Tool not found: nonexistent_tool"));
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_dispatch_list_tasks() {
+        let server = DelaMcpServer::new(std::env::temp_dir());
+        let (server_transport, _client_transport) = tokio::io::duplex(4096);
+        let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
+        let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
+
         let req = CallToolRequestParams::new("list_tasks");
-        let res = server.call_tool(req, context.clone()).await;
+        let res = server.call_tool(req, context).await;
         assert!(res.is_ok());
+    }
 
-        // 4. Test task_status (valid arguments)
-        let mut args_map = serde_json::Map::new();
-        args_map.insert("unique_name".to_string(), serde_json::Value::String("nonexistent".to_string()));
-        let req = CallToolRequestParams::new("task_status").with_arguments(args_map);
-        let res = server.call_tool(req, context.clone()).await;
+    #[tokio::test]
+    async fn test_call_tool_dispatch_status() {
+        let server = DelaMcpServer::new(std::env::temp_dir());
+        let (server_transport, _client_transport) = tokio::io::duplex(4096);
+        let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
+        let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
+
+        let req = CallToolRequestParams::new("status");
+        let res = server.call_tool(req, context).await;
         assert!(res.is_ok());
+    }
 
-        // 5. Test task_status (invalid arguments - should map_err)
-        let mut invalid_args_map = serde_json::Map::new();
-        invalid_args_map.insert("unique_name".to_string(), serde_json::Value::Bool(true));
-        let req = CallToolRequestParams::new("task_status").with_arguments(invalid_args_map);
-        let res = server.call_tool(req, context.clone()).await;
-        assert!(res.is_err());
+    #[tokio::test]
+    async fn test_call_tool_dispatch_task_status() {
+        let server = DelaMcpServer::new(std::env::temp_dir());
+        let (server_transport, _client_transport) = tokio::io::duplex(4096);
+        let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
+        let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
 
-        // 6. Test task_output (valid pid but nonexistent job - returns error)
-        let mut args_map = serde_json::Map::new();
-        args_map.insert("pid".to_string(), serde_json::Value::Number(12345.into()));
-        let req = CallToolRequestParams::new("task_output").with_arguments(args_map);
-        let res = server.call_tool(req, context.clone()).await;
-        assert!(res.is_err());
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "unique_name".to_string(),
+            serde_json::Value::String("nonexistent".to_string()),
+        );
+        let req = CallToolRequestParams::new("task_status").with_arguments(args);
+        let res = server.call_tool(req, context).await;
+        assert!(res.is_ok());
+    }
 
-        // 7. Test task_output (invalid arguments - should map_err)
-        let mut invalid_args_map = serde_json::Map::new();
-        invalid_args_map.insert("pid".to_string(), serde_json::Value::String("not_a_number".to_string()));
-        let req = CallToolRequestParams::new("task_output").with_arguments(invalid_args_map);
-        let res = server.call_tool(req, context.clone()).await;
-        assert!(res.is_err());
+    #[tokio::test]
+    async fn test_call_tool_dispatch_task_output() {
+        let server = DelaMcpServer::new(std::env::temp_dir());
+        let (server_transport, _client_transport) = tokio::io::duplex(4096);
+        let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
+        let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
 
-        // 8. Test task_stop (valid pid but nonexistent job - returns error)
-        let mut args_map = serde_json::Map::new();
-        args_map.insert("pid".to_string(), serde_json::Value::Number(12345.into()));
-        let req = CallToolRequestParams::new("task_stop").with_arguments(args_map);
-        let res = server.call_tool(req, context.clone()).await;
+        let mut args = serde_json::Map::new();
+        args.insert("pid".to_string(), serde_json::Value::Number(12345.into()));
+        let req = CallToolRequestParams::new("task_output").with_arguments(args);
+        let res = server.call_tool(req, context).await;
         assert!(res.is_err());
+    }
 
-        // 9. Test task_stop (invalid arguments - should map_err)
-        let mut invalid_args_map = serde_json::Map::new();
-        invalid_args_map.insert("pid".to_string(), serde_json::Value::String("not_a_number".to_string()));
-        let req = CallToolRequestParams::new("task_stop").with_arguments(invalid_args_map);
-        let res = server.call_tool(req, context.clone()).await;
-        assert!(res.is_err());
+    #[tokio::test]
+    async fn test_call_tool_dispatch_task_stop() {
+        let server = DelaMcpServer::new(std::env::temp_dir());
+        let (server_transport, _client_transport) = tokio::io::duplex(4096);
+        let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
+        let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
 
-        // 10. Test task_start (nonexistent task - returns error)
-        let mut args_map = serde_json::Map::new();
-        args_map.insert("unique_name".to_string(), serde_json::Value::String("nonexistent".to_string()));
-        let req = CallToolRequestParams::new("task_start").with_arguments(args_map);
-        let res = server.call_tool(req, context.clone()).await;
+        let mut args = serde_json::Map::new();
+        args.insert("pid".to_string(), serde_json::Value::Number(12345.into()));
+        let req = CallToolRequestParams::new("task_stop").with_arguments(args);
+        let res = server.call_tool(req, context).await;
         assert!(res.is_err());
+    }
 
-        // 11. Test task_start (invalid arguments - should map_err)
-        let mut invalid_args_map = serde_json::Map::new();
-        invalid_args_map.insert("unique_name".to_string(), serde_json::Value::Bool(false));
-        let req = CallToolRequestParams::new("task_start").with_arguments(invalid_args_map);
-        let res = server.call_tool(req, context.clone()).await;
+    #[tokio::test]
+    async fn test_call_tool_dispatch_task_start() {
+        let server = DelaMcpServer::new(std::env::temp_dir());
+        let (server_transport, _client_transport) = tokio::io::duplex(4096);
+        let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
+        let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
+
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "unique_name".to_string(),
+            serde_json::Value::String("nonexistent".to_string()),
+        );
+        let req = CallToolRequestParams::new("task_start").with_arguments(args);
+        let res = server.call_tool(req, context).await;
         assert!(res.is_err());
+        let err = res.unwrap_err();
+        assert_eq!(err.code.0, -32012); // TASK_NOT_FOUND
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -924,7 +924,7 @@ impl DelaMcpServer {
                     JobState::Signaled(_) => "signaled".to_string(),
                     _ => "exited".to_string(),
                 },
-                pid: Some(pid as i32),
+                pid: None,
                 exit_code,
                 signal,
                 output: output_chunks,
@@ -3510,7 +3510,7 @@ add_custom_target(build-all COMMENT "Build everything")
 
         assert_eq!(json["state"], "exited");
         assert_eq!(json["exit_code"], 0);
-        assert!(json.get("pid").is_some());
+        assert!(json.get("pid").is_none());
         let output_chunks = json["output"].as_array().unwrap();
         assert!(output_chunks.iter().any(|chunk| {
             chunk

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -435,6 +435,214 @@ impl DelaMcpServer {
         ]))
     }
 
+    async fn run_initial_capture(
+        peer: std::sync::Arc<tokio::sync::OnceCell<rmcp::service::Peer<rmcp::service::RoleServer>>>,
+        pid_u32: u32,
+        capture_duration: Duration,
+        mut stdout_rx: tokio::sync::mpsc::Receiver<String>,
+        mut stderr_rx: tokio::sync::mpsc::Receiver<String>,
+        captured_output_chunks: Arc<tokio::sync::Mutex<Vec<crate::mcp::dto::OutputChunkDto>>>,
+    ) -> (
+        tokio::sync::mpsc::Receiver<String>,
+        tokio::sync::mpsc::Receiver<String>,
+    ) {
+        let deadline = std::time::Instant::now() + capture_duration;
+        let mut stdout_done = false;
+        let mut stderr_done = false;
+        let mut stdout_batch = OutputNotificationBatch::new("stdout");
+        let mut stderr_batch = OutputNotificationBatch::new("stderr");
+
+        loop {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                break;
+            }
+
+            tokio::select! {
+                line = stdout_rx.recv(), if !stdout_done => {
+                    match line {
+                        Some(line) => {
+                            {
+                                let mut chunks = captured_output_chunks.lock().await;
+                                Self::append_output_chunk(&mut chunks, "stdout", &line);
+                            }
+                            stdout_batch.add_line(&line);
+                            if stdout_batch.should_flush() {
+                                Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                            }
+                        }
+                        None => {
+                            stdout_done = true;
+                            Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                        }
+                    }
+                }
+                line = stderr_rx.recv(), if !stderr_done => {
+                    match line {
+                        Some(line) => {
+                            {
+                                let mut chunks = captured_output_chunks.lock().await;
+                                Self::append_output_chunk(&mut chunks, "stderr", &line);
+                            }
+                            stderr_batch.add_line(&line);
+                            if stderr_batch.should_flush() {
+                                Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                            }
+                        }
+                        None => {
+                            stderr_done = true;
+                            Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                        }
+                    }
+                }
+                _ = tokio::time::sleep_until(Self::output_flush_timer_deadline(stdout_batch.flush_due_at(), deadline)), if !stdout_batch.is_empty() => {
+                    Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                }
+                _ = tokio::time::sleep_until(Self::output_flush_timer_deadline(stderr_batch.flush_due_at(), deadline)), if !stderr_batch.is_empty() => {
+                    Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                }
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {
+                    Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                    Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                    break;
+                }
+            }
+
+            if stdout_done && stderr_done {
+                Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                break;
+            }
+        }
+
+        (stdout_rx, stderr_rx)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_background_monitoring(
+        peer: std::sync::Arc<tokio::sync::OnceCell<rmcp::service::Peer<rmcp::service::RoleServer>>>,
+        pid_u32: u32,
+        task_name: String,
+        mut stdout_rx_opt: Option<tokio::sync::mpsc::Receiver<String>>,
+        mut stderr_rx_opt: Option<tokio::sync::mpsc::Receiver<String>>,
+        job_manager: crate::mcp::job_manager::JobManager,
+    ) {
+        let mut stdout_batch = OutputNotificationBatch::new("stdout");
+        let mut stderr_batch = OutputNotificationBatch::new("stderr");
+        let idle_deadline_fallback = Instant::now() + Duration::from_secs(24 * 60 * 60);
+
+        loop {
+            let stdout_done = stdout_rx_opt.is_none();
+            let stderr_done = stderr_rx_opt.is_none();
+
+            tokio::select! {
+                line = async {
+                    if let Some(ref mut rx) = stdout_rx_opt {
+                        rx.recv().await
+                    } else {
+                        std::future::pending::<Option<String>>().await
+                    }
+                }, if !stdout_done => {
+                    match line {
+                        Some(line) => {
+                            if let Err(error) = job_manager.add_job_output_chunk(pid_u32, "stdout", line.clone()).await {
+                                tracing::warn!(pid = pid_u32, error = %error, "failed to persist stdout output chunk");
+                            }
+                            stdout_batch.add_line(&line);
+                            if stdout_batch.should_flush() {
+                                Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                            }
+                        }
+                        None => {
+                            stdout_rx_opt = None;
+                            Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                        }
+                    }
+                }
+                line = async {
+                    if let Some(ref mut rx) = stderr_rx_opt {
+                        rx.recv().await
+                    } else {
+                        std::future::pending::<Option<String>>().await
+                    }
+                }, if !stderr_done => {
+                    match line {
+                        Some(line) => {
+                            if let Err(error) = job_manager.add_job_output_chunk(pid_u32, "stderr", line.clone()).await {
+                                tracing::warn!(pid = pid_u32, error = %error, "failed to persist stderr output chunk");
+                            }
+                            stderr_batch.add_line(&line);
+                            if stderr_batch.should_flush() {
+                                Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                            }
+                        }
+                        None => {
+                            stderr_rx_opt = None;
+                            Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                        }
+                    }
+                }
+                _ = tokio::time::sleep_until(Self::output_flush_timer_deadline(stdout_batch.flush_due_at(), idle_deadline_fallback)), if !stdout_batch.is_empty() => {
+                    Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                }
+                _ = tokio::time::sleep_until(Self::output_flush_timer_deadline(stderr_batch.flush_due_at(), idle_deadline_fallback)), if !stderr_batch.is_empty() => {
+                    Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                }
+                else => {
+                    Self::flush_output_notification_batch(&peer, pid_u32, &mut stdout_batch).await;
+                    Self::flush_output_notification_batch(&peer, pid_u32, &mut stderr_batch).await;
+                    break;
+                }
+            }
+        }
+
+        if let Some(mut process) = job_manager.processes.write().await.remove(&pid_u32) {
+            let exit_result = process.wait().await;
+            let (state, exit_code, signal) = match exit_result {
+                Ok(status) => {
+                    let mut state = JobState::Exited(status.code().unwrap_or(-1));
+                    let mut exit_code = status.code();
+                    let mut signal = None;
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::process::ExitStatusExt;
+                        if let Some(sig) = status.signal() {
+                            state = JobState::Signaled(sig);
+                            signal = Some(sig);
+                            exit_code = None;
+                        }
+                    }
+                    (state, exit_code, signal)
+                }
+                Err(e) => (
+                    JobState::Failed(format!("Process wait failed: {}", e)),
+                    None,
+                    None,
+                ),
+            };
+
+            let _ = job_manager.update_job_state(pid_u32, state).await;
+
+            if let Some(peer_ref) = peer.get() {
+                let _ = peer_ref
+                    .notify_logging_message(rmcp::model::LoggingMessageNotificationParam {
+                        level: LoggingLevel::Notice,
+                        logger: Some(format!("task:{}", pid_u32)),
+                        data: serde_json::json!({
+                            "event": "exited",
+                            "pid": pid_u32,
+                            "exit_code": exit_code,
+                            "signal": signal,
+                            "task": task_name
+                        }),
+                    })
+                    .await;
+            }
+        }
+    }
+
     #[tool(
         description = "Start a task (default 1s capture, optional bounded wait, then background)"
     )]
@@ -568,8 +776,8 @@ impl DelaMcpServer {
         let peer_clone = self.peer.clone();
 
         // Create channels for output streaming
-        let (stdout_tx, mut stdout_rx) = tokio::sync::mpsc::channel::<String>(100);
-        let (stderr_tx, mut stderr_rx) = tokio::sync::mpsc::channel::<String>(100);
+        let (stdout_tx, stdout_rx) = tokio::sync::mpsc::channel::<String>(100);
+        let (stderr_tx, stderr_rx) = tokio::sync::mpsc::channel::<String>(100);
 
         // Spawn stdout reader task
         let stdout_task = if let Some(stdout) = stdout_handle {
@@ -620,147 +828,14 @@ impl DelaMcpServer {
         let peer_for_initial = peer_clone.clone();
         let pid_u32 = pid as u32;
 
-        let initial_capture = tokio::spawn(async move {
-            let deadline = std::time::Instant::now() + capture_duration;
-            let mut stdout_done = false;
-            let mut stderr_done = false;
-            let mut stdout_batch = OutputNotificationBatch::new("stdout");
-            let mut stderr_batch = OutputNotificationBatch::new("stderr");
-
-            loop {
-                let now = std::time::Instant::now();
-                if now >= deadline {
-                    DelaMcpServer::flush_output_notification_batch(
-                        &peer_for_initial,
-                        pid_u32,
-                        &mut stdout_batch,
-                    )
-                    .await;
-                    DelaMcpServer::flush_output_notification_batch(
-                        &peer_for_initial,
-                        pid_u32,
-                        &mut stderr_batch,
-                    )
-                    .await;
-                    break;
-                }
-
-                tokio::select! {
-                    line = stdout_rx.recv(), if !stdout_done => {
-                        match line {
-                            Some(line) => {
-                                {
-                                    let mut chunks = captured_output_chunks_clone.lock().await;
-                                    DelaMcpServer::append_output_chunk(&mut chunks, "stdout", &line);
-                                }
-                                stdout_batch.add_line(&line);
-                                if stdout_batch.should_flush() {
-                                    DelaMcpServer::flush_output_notification_batch(
-                                        &peer_for_initial,
-                                        pid_u32,
-                                        &mut stdout_batch,
-                                    )
-                                    .await;
-                                }
-                            }
-                            None => {
-                                stdout_done = true;
-                                DelaMcpServer::flush_output_notification_batch(
-                                    &peer_for_initial,
-                                    pid_u32,
-                                    &mut stdout_batch,
-                                )
-                                .await;
-                            }
-                        }
-                    }
-                    line = stderr_rx.recv(), if !stderr_done => {
-                        match line {
-                            Some(line) => {
-                                {
-                                    let mut chunks = captured_output_chunks_clone.lock().await;
-                                    DelaMcpServer::append_output_chunk(&mut chunks, "stderr", &line);
-                                }
-                                stderr_batch.add_line(&line);
-                                if stderr_batch.should_flush() {
-                                    DelaMcpServer::flush_output_notification_batch(
-                                        &peer_for_initial,
-                                        pid_u32,
-                                        &mut stderr_batch,
-                                    )
-                                    .await;
-                                }
-                            }
-                            None => {
-                                stderr_done = true;
-                                DelaMcpServer::flush_output_notification_batch(
-                                    &peer_for_initial,
-                                    pid_u32,
-                                    &mut stderr_batch,
-                                )
-                                .await;
-                            }
-                        }
-                    }
-                    _ = tokio::time::sleep_until(DelaMcpServer::output_flush_timer_deadline(
-                        stdout_batch.flush_due_at(),
-                        deadline,
-                    )), if !stdout_batch.is_empty() => {
-                        DelaMcpServer::flush_output_notification_batch(
-                            &peer_for_initial,
-                            pid_u32,
-                            &mut stdout_batch,
-                        )
-                        .await;
-                    }
-                    _ = tokio::time::sleep_until(DelaMcpServer::output_flush_timer_deadline(
-                        stderr_batch.flush_due_at(),
-                        deadline,
-                    )), if !stderr_batch.is_empty() => {
-                        DelaMcpServer::flush_output_notification_batch(
-                            &peer_for_initial,
-                            pid_u32,
-                            &mut stderr_batch,
-                        )
-                        .await;
-                    }
-                    _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {
-                        DelaMcpServer::flush_output_notification_batch(
-                            &peer_for_initial,
-                            pid_u32,
-                            &mut stdout_batch,
-                        )
-                        .await;
-                        DelaMcpServer::flush_output_notification_batch(
-                            &peer_for_initial,
-                            pid_u32,
-                            &mut stderr_batch,
-                        )
-                        .await;
-                        break;
-                    }
-                }
-
-                if stdout_done && stderr_done {
-                    DelaMcpServer::flush_output_notification_batch(
-                        &peer_for_initial,
-                        pid_u32,
-                        &mut stdout_batch,
-                    )
-                    .await;
-                    DelaMcpServer::flush_output_notification_batch(
-                        &peer_for_initial,
-                        pid_u32,
-                        &mut stderr_batch,
-                    )
-                    .await;
-                    break;
-                }
-            }
-
-            // Return the receivers for continued streaming
-            (stdout_rx, stderr_rx)
-        });
+        let initial_capture = tokio::spawn(Self::run_initial_capture(
+            peer_for_initial,
+            pid_u32,
+            capture_duration,
+            stdout_rx,
+            stderr_rx,
+            captured_output_chunks_clone,
+        ));
 
         let capture_result = initial_capture.await;
 
@@ -902,190 +977,20 @@ impl DelaMcpServer {
         let peer_for_monitor = peer_clone;
         let task_name = args.unique_name.clone();
 
-        tokio::spawn(async move {
-            // Get the receivers from initial capture (if available)
-            let (mut stdout_rx_opt, mut stderr_rx_opt) = if let Ok((rx1, rx2)) = capture_result {
-                (Some(rx1), Some(rx2))
-            } else {
-                (None, None)
-            };
-            let mut stdout_batch = OutputNotificationBatch::new("stdout");
-            let mut stderr_batch = OutputNotificationBatch::new("stderr");
-            let idle_deadline_fallback = Instant::now() + Duration::from_secs(24 * 60 * 60);
+        let (stdout_rx_opt, stderr_rx_opt) = if let Ok((rx1, rx2)) = capture_result {
+            (Some(rx1), Some(rx2))
+        } else {
+            (None, None)
+        };
 
-            // Continue reading output and streaming
-            loop {
-                let stdout_done = stdout_rx_opt.is_none();
-                let stderr_done = stderr_rx_opt.is_none();
-
-                tokio::select! {
-                    line = async {
-                        if let Some(ref mut rx) = stdout_rx_opt {
-                            rx.recv().await
-                        } else {
-                            std::future::pending::<Option<String>>().await
-                        }
-                    }, if !stdout_done => {
-                        match line {
-                            Some(line) => {
-                                if let Err(error) = job_manager
-                                    .add_job_output_chunk(pid_u32, "stdout", line.clone())
-                                    .await
-                                {
-                                    tracing::warn!(
-                                        pid = pid_u32,
-                                        error = %error,
-                                        "failed to persist stdout output chunk"
-                                    );
-                                }
-                                stdout_batch.add_line(&line);
-                                if stdout_batch.should_flush() {
-                                    DelaMcpServer::flush_output_notification_batch(
-                                        &peer_for_monitor,
-                                        pid_u32,
-                                        &mut stdout_batch,
-                                    )
-                                    .await;
-                                }
-                            }
-                            None => {
-                                stdout_rx_opt = None;
-                                DelaMcpServer::flush_output_notification_batch(
-                                    &peer_for_monitor,
-                                    pid_u32,
-                                    &mut stdout_batch,
-                                )
-                                .await;
-                            }
-                        }
-                    }
-                    line = async {
-                        if let Some(ref mut rx) = stderr_rx_opt {
-                            rx.recv().await
-                        } else {
-                            std::future::pending::<Option<String>>().await
-                        }
-                    }, if !stderr_done => {
-                        match line {
-                            Some(line) => {
-                                if let Err(error) = job_manager
-                                    .add_job_output_chunk(pid_u32, "stderr", line.clone())
-                                    .await
-                                {
-                                    tracing::warn!(
-                                        pid = pid_u32,
-                                        error = %error,
-                                        "failed to persist stderr output chunk"
-                                    );
-                                }
-                                stderr_batch.add_line(&line);
-                                if stderr_batch.should_flush() {
-                                    DelaMcpServer::flush_output_notification_batch(
-                                        &peer_for_monitor,
-                                        pid_u32,
-                                        &mut stderr_batch,
-                                    )
-                                    .await;
-                                }
-                            }
-                            None => {
-                                stderr_rx_opt = None;
-                                DelaMcpServer::flush_output_notification_batch(
-                                    &peer_for_monitor,
-                                    pid_u32,
-                                    &mut stderr_batch,
-                                )
-                                .await;
-                            }
-                        }
-                    }
-                    _ = tokio::time::sleep_until(DelaMcpServer::output_flush_timer_deadline(
-                        stdout_batch.flush_due_at(),
-                        idle_deadline_fallback,
-                    )), if !stdout_batch.is_empty() => {
-                        DelaMcpServer::flush_output_notification_batch(
-                            &peer_for_monitor,
-                            pid_u32,
-                            &mut stdout_batch,
-                        )
-                        .await;
-                    }
-                    _ = tokio::time::sleep_until(DelaMcpServer::output_flush_timer_deadline(
-                        stderr_batch.flush_due_at(),
-                        idle_deadline_fallback,
-                    )), if !stderr_batch.is_empty() => {
-                        DelaMcpServer::flush_output_notification_batch(
-                            &peer_for_monitor,
-                            pid_u32,
-                            &mut stderr_batch,
-                        )
-                        .await;
-                    }
-                    else => {
-                        // Both channels closed
-                        DelaMcpServer::flush_output_notification_batch(
-                            &peer_for_monitor,
-                            pid_u32,
-                            &mut stdout_batch,
-                        )
-                        .await;
-                        DelaMcpServer::flush_output_notification_batch(
-                            &peer_for_monitor,
-                            pid_u32,
-                            &mut stderr_batch,
-                        )
-                        .await;
-                        break;
-                    }
-                }
-            }
-
-            // Wait for process to exit
-            if let Some(mut process) = job_manager.processes.write().await.remove(&pid_u32) {
-                let exit_result = process.wait().await;
-                let (state, exit_code, signal) = match exit_result {
-                    Ok(status) => {
-                        let mut state = JobState::Exited(status.code().unwrap_or(-1));
-                        let mut exit_code = status.code();
-                        let mut signal = None;
-                        #[cfg(unix)]
-                        {
-                            use std::os::unix::process::ExitStatusExt;
-                            if let Some(sig) = status.signal() {
-                                state = JobState::Signaled(sig);
-                                signal = Some(sig);
-                                exit_code = None;
-                            }
-                        }
-                        (state, exit_code, signal)
-                    }
-                    Err(e) => (
-                        JobState::Failed(format!("Process wait failed: {}", e)),
-                        None,
-                        None,
-                    ),
-                };
-
-                let _ = job_manager.update_job_state(pid_u32, state).await;
-
-                // Send task completed event
-                if let Some(peer) = peer_for_monitor.get() {
-                    let _ = peer
-                        .notify_logging_message(LoggingMessageNotificationParam {
-                            level: LoggingLevel::Notice,
-                            logger: Some(format!("task:{}", pid_u32)),
-                            data: serde_json::json!({
-                                "event": "exited",
-                                "pid": pid_u32,
-                                "exit_code": exit_code,
-                                "signal": signal,
-                                "task": task_name
-                            }),
-                        })
-                        .await;
-                }
-            }
-        });
+        tokio::spawn(Self::run_background_monitoring(
+            peer_for_monitor,
+            pid_u32,
+            task_name,
+            stdout_rx_opt,
+            stderr_rx_opt,
+            job_manager,
+        ));
 
         let start_result = StartResultDto {
             state: "running".to_string(),
@@ -1208,9 +1113,10 @@ impl DelaMcpServer {
         if has_more {
             response["has_more_lines"] = serde_json::Value::Bool(true);
         }
-        
+
         if dropped_lines > 0 {
-            response["dropped_lines"] = serde_json::Value::Number(serde_json::Number::from(dropped_lines));
+            response["dropped_lines"] =
+                serde_json::Value::Number(serde_json::Number::from(dropped_lines));
         }
 
         // Add truncation details if requested

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -146,6 +146,7 @@ struct CachedDiscoveredTasks {
 }
 
 /// MCP server for dela that exposes task management capabilities
+#[derive(Clone)]
 pub struct DelaMcpServer {
     root: PathBuf,
     allowlist_evaluator: McpAllowlistEvaluator,
@@ -4275,5 +4276,88 @@ add_custom_target(build-all COMMENT "Build everything")
 
         assert!(instructions.contains("wait_for_exit_seconds"));
         assert!(instructions.contains("default 1-second capture window"));
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_all_cases() {
+        let temp_dir = std::env::temp_dir();
+        let server = DelaMcpServer::new(temp_dir);
+
+        let (server_transport, _client_transport) = tokio::io::duplex(4096);
+        let running_server = rmcp::service::serve_directly(server.clone(), server_transport, None);
+        let peer = running_server.peer().clone();
+
+        let context = RequestContext::new(RequestId::Number(1), peer);
+
+        // 1. Test status (no arguments)
+        let req = CallToolRequestParams::new("status");
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_ok());
+
+        // 2. Test invalid tool name
+        let req = CallToolRequestParams::new("invalid_tool_name");
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_err());
+
+        // 3. Test list_tasks (empty arguments is ok)
+        let req = CallToolRequestParams::new("list_tasks");
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_ok());
+
+        // 4. Test task_status (valid arguments)
+        let mut args_map = serde_json::Map::new();
+        args_map.insert("unique_name".to_string(), serde_json::Value::String("nonexistent".to_string()));
+        let req = CallToolRequestParams::new("task_status").with_arguments(args_map);
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_ok());
+
+        // 5. Test task_status (invalid arguments - should map_err)
+        let mut invalid_args_map = serde_json::Map::new();
+        invalid_args_map.insert("unique_name".to_string(), serde_json::Value::Bool(true));
+        let req = CallToolRequestParams::new("task_status").with_arguments(invalid_args_map);
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_err());
+
+        // 6. Test task_output (valid pid but nonexistent job - returns error)
+        let mut args_map = serde_json::Map::new();
+        args_map.insert("pid".to_string(), serde_json::Value::Number(12345.into()));
+        let req = CallToolRequestParams::new("task_output").with_arguments(args_map);
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_err());
+
+        // 7. Test task_output (invalid arguments - should map_err)
+        let mut invalid_args_map = serde_json::Map::new();
+        invalid_args_map.insert("pid".to_string(), serde_json::Value::String("not_a_number".to_string()));
+        let req = CallToolRequestParams::new("task_output").with_arguments(invalid_args_map);
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_err());
+
+        // 8. Test task_stop (valid pid but nonexistent job - returns error)
+        let mut args_map = serde_json::Map::new();
+        args_map.insert("pid".to_string(), serde_json::Value::Number(12345.into()));
+        let req = CallToolRequestParams::new("task_stop").with_arguments(args_map);
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_err());
+
+        // 9. Test task_stop (invalid arguments - should map_err)
+        let mut invalid_args_map = serde_json::Map::new();
+        invalid_args_map.insert("pid".to_string(), serde_json::Value::String("not_a_number".to_string()));
+        let req = CallToolRequestParams::new("task_stop").with_arguments(invalid_args_map);
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_err());
+
+        // 10. Test task_start (nonexistent task - returns error)
+        let mut args_map = serde_json::Map::new();
+        args_map.insert("unique_name".to_string(), serde_json::Value::String("nonexistent".to_string()));
+        let req = CallToolRequestParams::new("task_start").with_arguments(args_map);
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_err());
+
+        // 11. Test task_start (invalid arguments - should map_err)
+        let mut invalid_args_map = serde_json::Map::new();
+        invalid_args_map.insert("unique_name".to_string(), serde_json::Value::Bool(false));
+        let req = CallToolRequestParams::new("task_start").with_arguments(invalid_args_map);
+        let res = server.call_tool(req, context.clone()).await;
+        assert!(res.is_err());
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -598,7 +598,8 @@ impl DelaMcpServer {
             }
         }
 
-        if let Some(mut process) = job_manager.processes.write().await.remove(&pid_u32) {
+        let process_opt = job_manager.processes.write().await.remove(&pid_u32);
+        if let Some(mut process) = process_opt {
             let exit_result = process.wait().await;
             let (state, exit_code, signal) = match exit_result {
                 Ok(status) => {

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -131,11 +131,9 @@ fn handle_key_code(code: KeyCode, selected: usize, options_len: usize) -> KeyAct
             KeyActionResult::Continue { new_selected }
         }
         KeyCode::Home | KeyCode::Char('g') => KeyActionResult::Continue { new_selected: 0 },
-        KeyCode::End | KeyCode::Char('G') => {
-            KeyActionResult::Continue {
-                new_selected: options_len.saturating_sub(1),
-            }
-        }
+        KeyCode::End | KeyCode::Char('G') => KeyActionResult::Continue {
+            new_selected: options_len.saturating_sub(1),
+        },
         KeyCode::Enter => KeyActionResult::Select(selected),
         _ => KeyActionResult::Ignore,
     }
@@ -393,32 +391,75 @@ mod tests {
 
     #[test]
     fn test_handle_key_code_cancel() {
-        assert_eq!(handle_key_code(KeyCode::Char('q'), 0, 5), KeyActionResult::Cancel);
+        assert_eq!(
+            handle_key_code(KeyCode::Char('q'), 0, 5),
+            KeyActionResult::Cancel
+        );
         assert_eq!(handle_key_code(KeyCode::Esc, 1, 5), KeyActionResult::Cancel);
     }
 
     #[test]
     fn test_handle_key_code_navigation() {
-        // Up / k
-        assert_eq!(handle_key_code(KeyCode::Up, 1, 5), KeyActionResult::Continue { new_selected: 0 });
-        assert_eq!(handle_key_code(KeyCode::Char('k'), 0, 5), KeyActionResult::Continue { new_selected: 4 });
+        assert_eq!(
+            handle_key_code(KeyCode::Up, 1, 5),
+            KeyActionResult::Continue { new_selected: 0 }
+        );
+        assert_eq!(
+            handle_key_code(KeyCode::Char('k'), 0, 5),
+            KeyActionResult::Continue { new_selected: 4 }
+        );
 
-        // Down / j
-        assert_eq!(handle_key_code(KeyCode::Down, 1, 5), KeyActionResult::Continue { new_selected: 2 });
-        assert_eq!(handle_key_code(KeyCode::Char('j'), 4, 5), KeyActionResult::Continue { new_selected: 0 });
+        assert_eq!(
+            handle_key_code(KeyCode::Down, 1, 5),
+            KeyActionResult::Continue { new_selected: 2 }
+        );
+        assert_eq!(
+            handle_key_code(KeyCode::Char('j'), 4, 5),
+            KeyActionResult::Continue { new_selected: 0 }
+        );
 
-        // Home / g
-        assert_eq!(handle_key_code(KeyCode::Home, 3, 5), KeyActionResult::Continue { new_selected: 0 });
-        assert_eq!(handle_key_code(KeyCode::Char('g'), 3, 5), KeyActionResult::Continue { new_selected: 0 });
+        assert_eq!(
+            handle_key_code(KeyCode::Home, 3, 5),
+            KeyActionResult::Continue { new_selected: 0 }
+        );
+        assert_eq!(
+            handle_key_code(KeyCode::Char('g'), 3, 5),
+            KeyActionResult::Continue { new_selected: 0 }
+        );
 
-        // End / G
-        assert_eq!(handle_key_code(KeyCode::End, 1, 5), KeyActionResult::Continue { new_selected: 4 });
-        assert_eq!(handle_key_code(KeyCode::Char('G'), 1, 5), KeyActionResult::Continue { new_selected: 4 });
+        assert_eq!(
+            handle_key_code(KeyCode::End, 1, 5),
+            KeyActionResult::Continue { new_selected: 4 }
+        );
+        assert_eq!(
+            handle_key_code(KeyCode::Char('G'), 1, 5),
+            KeyActionResult::Continue { new_selected: 4 }
+        );
 
-        // Enter
-        assert_eq!(handle_key_code(KeyCode::Enter, 2, 5), KeyActionResult::Select(2));
+        assert_eq!(
+            handle_key_code(KeyCode::Enter, 2, 5),
+            KeyActionResult::Select(2)
+        );
 
-        // Ignore
-        assert_eq!(handle_key_code(KeyCode::Char('x'), 2, 5), KeyActionResult::Ignore);
+        assert_eq!(
+            handle_key_code(KeyCode::Char('x'), 2, 5),
+            KeyActionResult::Ignore
+        );
+    }
+
+    #[test]
+    fn test_handle_key_code_empty_options() {
+        assert_eq!(
+            handle_key_code(KeyCode::Up, 0, 0),
+            KeyActionResult::Continue { new_selected: 0 }
+        );
+        assert_eq!(
+            handle_key_code(KeyCode::Down, 0, 0),
+            KeyActionResult::Continue { new_selected: 0 }
+        );
+        assert_eq!(
+            handle_key_code(KeyCode::End, 0, 0),
+            KeyActionResult::Continue { new_selected: 0 }
+        );
     }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -103,6 +103,44 @@ fn prompt_for_task_fallback(task: &Task) -> anyhow::Result<AllowDecision> {
     }
 }
 
+#[derive(Debug, PartialEq, Clone)]
+enum KeyActionResult {
+    Continue { new_selected: usize },
+    Select(usize),
+    Cancel,
+    Ignore,
+}
+
+fn handle_key_code(code: KeyCode, selected: usize, options_len: usize) -> KeyActionResult {
+    match code {
+        KeyCode::Char('q') | KeyCode::Esc => KeyActionResult::Cancel,
+        KeyCode::Up | KeyCode::Char('k') => {
+            let new_selected = if selected == 0 {
+                options_len.saturating_sub(1)
+            } else {
+                selected - 1
+            };
+            KeyActionResult::Continue { new_selected }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            let new_selected = if options_len == 0 {
+                0
+            } else {
+                (selected + 1) % options_len
+            };
+            KeyActionResult::Continue { new_selected }
+        }
+        KeyCode::Home | KeyCode::Char('g') => KeyActionResult::Continue { new_selected: 0 },
+        KeyCode::End | KeyCode::Char('G') => {
+            KeyActionResult::Continue {
+                new_selected: options_len.saturating_sub(1),
+            }
+        }
+        KeyCode::Enter => KeyActionResult::Select(selected),
+        _ => KeyActionResult::Ignore,
+    }
+}
+
 fn run_tui(
     terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     task: &Task,
@@ -137,30 +175,17 @@ fn run_tui(
         if let Event::Key(key) =
             event::read().map_err(|e| anyhow::anyhow!("Failed to read event: {}", e))?
         {
-            match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => {
+            match handle_key_code(key.code, selected, options.len()) {
+                KeyActionResult::Continue { new_selected } => {
+                    selected = new_selected;
+                }
+                KeyActionResult::Select(index) => {
+                    return Ok(options[index].1.clone());
+                }
+                KeyActionResult::Cancel => {
                     return Err(anyhow::anyhow!("User cancelled"));
                 }
-                KeyCode::Up | KeyCode::Char('k') => {
-                    selected = if selected == 0 {
-                        options.len() - 1
-                    } else {
-                        selected - 1
-                    };
-                }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    selected = (selected + 1) % options.len();
-                }
-                KeyCode::Home | KeyCode::Char('g') => {
-                    selected = 0;
-                }
-                KeyCode::End | KeyCode::Char('G') => {
-                    selected = options.len() - 1;
-                }
-                KeyCode::Enter => {
-                    return Ok(options[selected].1.clone());
-                }
-                _ => {}
+                KeyActionResult::Ignore => {}
             }
         }
     }
@@ -364,5 +389,36 @@ mod tests {
         assert!(contents.contains("test-task"));
         assert!(contents.contains("Allow once"));
         assert!(contents.contains("Deny"));
+    }
+
+    #[test]
+    fn test_handle_key_code_cancel() {
+        assert_eq!(handle_key_code(KeyCode::Char('q'), 0, 5), KeyActionResult::Cancel);
+        assert_eq!(handle_key_code(KeyCode::Esc, 1, 5), KeyActionResult::Cancel);
+    }
+
+    #[test]
+    fn test_handle_key_code_navigation() {
+        // Up / k
+        assert_eq!(handle_key_code(KeyCode::Up, 1, 5), KeyActionResult::Continue { new_selected: 0 });
+        assert_eq!(handle_key_code(KeyCode::Char('k'), 0, 5), KeyActionResult::Continue { new_selected: 4 });
+
+        // Down / j
+        assert_eq!(handle_key_code(KeyCode::Down, 1, 5), KeyActionResult::Continue { new_selected: 2 });
+        assert_eq!(handle_key_code(KeyCode::Char('j'), 4, 5), KeyActionResult::Continue { new_selected: 0 });
+
+        // Home / g
+        assert_eq!(handle_key_code(KeyCode::Home, 3, 5), KeyActionResult::Continue { new_selected: 0 });
+        assert_eq!(handle_key_code(KeyCode::Char('g'), 3, 5), KeyActionResult::Continue { new_selected: 0 });
+
+        // End / G
+        assert_eq!(handle_key_code(KeyCode::End, 1, 5), KeyActionResult::Continue { new_selected: 4 });
+        assert_eq!(handle_key_code(KeyCode::Char('G'), 1, 5), KeyActionResult::Continue { new_selected: 4 });
+
+        // Enter
+        assert_eq!(handle_key_code(KeyCode::Enter, 2, 5), KeyActionResult::Select(2));
+
+        // Ignore
+        assert_eq!(handle_key_code(KeyCode::Char('x'), 2, 5), KeyActionResult::Ignore);
     }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -134,7 +134,13 @@ fn handle_key_code(code: KeyCode, selected: usize, options_len: usize) -> KeyAct
         KeyCode::End | KeyCode::Char('G') => KeyActionResult::Continue {
             new_selected: options_len.saturating_sub(1),
         },
-        KeyCode::Enter => KeyActionResult::Select(selected),
+        KeyCode::Enter => {
+            if options_len == 0 {
+                KeyActionResult::Ignore
+            } else {
+                KeyActionResult::Select(selected)
+            }
+        }
         _ => KeyActionResult::Ignore,
     }
 }

--- a/tests/Dockerfile.builder
+++ b/tests/Dockerfile.builder
@@ -9,7 +9,8 @@ RUN apk add --no-cache \
     make \
     openssl-dev \
     pkgconfig \
-    procps
+    procps \
+    python3
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -508,7 +508,7 @@ def test_running_lifecycle_and_stop():
         stop_payload = parse_tool_result(stop_response)
         assert_condition(stop_payload["pid"] == pid, "task_stop pid mismatch", stop_payload)
         assert_condition(
-            stop_payload["status"] in {"graceful", "killed", "failed"},
+            stop_payload["status"] in {"graceful", "killed", "failed", "signaled"},
             "unexpected task_stop status",
             stop_payload,
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool argument validation with consistent “Invalid arguments” errors and improved handling of missing parameters.
  * Enhanced graceful job termination and reporting for signaled exits (including signal details) and updated exited counts.
  * Refreshed MCP task responses: `task_start`/`task_status`/`task_stop` now distinguish exited vs signaled, and `task_output` now reports `has_more_lines` and dropped-line indicators.
* **Tests**
  * Expanded coverage for managed/unmanaged job stopping (SIGTERM/SIGKILL, already-exited cases), server tool dispatch/error paths, and prompt keyboard navigation (including empty-options behavior).
* **Documentation**
  * Updated MCP init Antigravity configuration path in README, CLI help, and related editor config instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->