### PR TITLE
pass pid and cwd to mcp explicitly

### DIFF
--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -390,7 +390,10 @@ mod tests {
             runner: Some("npm".to_string()),
             ..Default::default()
         };
-        let args_without_runner = ListTasksArgs { runner: None, ..Default::default() };
+        let args_without_runner = ListTasksArgs {
+            runner: None,
+            ..Default::default()
+        };
 
         // Act
         let json_with = serde_json::to_string(&args_with_runner).expect("Should serialize");

--- a/src/mcp/dto.rs
+++ b/src/mcp/dto.rs
@@ -90,6 +90,9 @@ pub struct ListTasksArgs {
     /// Optional runner filter - if provided, only return tasks for this runner
     /// Examples: "make", "npm", "gradle", "poetry"
     pub runner: Option<String>,
+
+    /// Optional working directory to discover tasks in
+    pub cwd: Option<String>,
 }
 
 #[cfg(test)]
@@ -373,6 +376,7 @@ mod tests {
         // Arrange & Act
         let args = ListTasksArgs {
             runner: Some("make".to_string()),
+            ..Default::default()
         };
 
         // Assert
@@ -384,8 +388,9 @@ mod tests {
         // Arrange
         let args_with_runner = ListTasksArgs {
             runner: Some("npm".to_string()),
+            ..Default::default()
         };
-        let args_without_runner = ListTasksArgs { runner: None };
+        let args_without_runner = ListTasksArgs { runner: None, ..Default::default() };
 
         // Act
         let json_with = serde_json::to_string(&args_with_runner).expect("Should serialize");
@@ -675,8 +680,8 @@ pub struct StartResultDto {
 /// Arguments for the task_status tool
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct TaskStatusArgs {
-    /// The unique name of the task to get status for
-    pub unique_name: String,
+    /// The PID of the job to get status for
+    pub pid: u32,
 }
 
 /// Arguments for the task_output tool

--- a/src/mcp/errors.rs
+++ b/src/mcp/errors.rs
@@ -165,6 +165,14 @@ impl DelaError {
         }
     }
 
+    /// Create a TaskNotFound error for PID-based job lookups
+    pub fn job_not_found(pid: u32) -> Self {
+        DelaError::TaskNotFound {
+            task_name: format!("Job with PID {} not found", pid),
+            hint: Some("Use 'status' to see running tasks and their PIDs".to_string()),
+        }
+    }
+
     /// Create an InternalError with a helpful hint
     pub fn internal_error(message: String, hint: Option<String>) -> Self {
         DelaError::InternalError { message, hint }

--- a/src/mcp/errors.rs
+++ b/src/mcp/errors.rs
@@ -48,6 +48,8 @@ pub enum DelaError {
         task_name: String,
         hint: Option<String>,
     },
+    /// Job with the given PID was not found
+    JobNotFound { pid: u32, hint: Option<String> },
     /// Generic internal error
     InternalError {
         message: String,
@@ -87,6 +89,11 @@ impl DelaError {
             DelaError::TaskNotFound { task_name, hint } => ErrorData {
                 code: DelaErrorCode::TASK_NOT_FOUND.into(),
                 message: Cow::Owned(format!("Task '{}' not found", task_name)),
+                data: hint.as_ref().map(|h| Value::String(h.clone())),
+            },
+            DelaError::JobNotFound { pid, hint } => ErrorData {
+                code: DelaErrorCode::TASK_NOT_FOUND.into(),
+                message: Cow::Owned(format!("Job with PID {} not found", pid)),
                 data: hint.as_ref().map(|h| Value::String(h.clone())),
             },
             DelaError::InternalError { message, hint } => ErrorData {
@@ -165,10 +172,10 @@ impl DelaError {
         }
     }
 
-    /// Create a TaskNotFound error for PID-based job lookups
+    /// Create a JobNotFound error for PID-based job lookups
     pub fn job_not_found(pid: u32) -> Self {
-        DelaError::TaskNotFound {
-            task_name: format!("Job with PID {} not found", pid),
+        DelaError::JobNotFound {
+            pid,
             hint: Some("Use 'status' to see running tasks and their PIDs".to_string()),
         }
     }
@@ -343,6 +350,24 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .contains("dela init")
+        );
+    }
+
+    #[test]
+    fn test_job_not_found_error() {
+        let error = DelaError::job_not_found(12345);
+        let error_data = error.to_error_data();
+
+        assert_eq!(error_data.code.0, -32012);
+        assert_eq!(error_data.message.as_ref(), "Job with PID 12345 not found");
+        assert!(
+            error_data
+                .data
+                .as_ref()
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .contains("status")
         );
     }
 }

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -447,14 +447,6 @@ impl JobManager {
         jobs.values().cloned().collect()
     }
 
-    /// Get jobs by unique name
-    pub async fn get_jobs_by_name(&self, unique_name: &str) -> Vec<Job> {
-        let jobs = self.jobs.read().await;
-        jobs.values()
-            .filter(|job| job.metadata.unique_name == unique_name)
-            .cloned()
-            .collect()
-    }
 
     /// Update a job's state
     pub async fn update_job_state(&self, pid: u32, state: JobState) -> anyhow::Result<()> {

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -447,7 +447,6 @@ impl JobManager {
         jobs.values().cloned().collect()
     }
 
-
     /// Update a job's state
     pub async fn update_job_state(&self, pid: u32, state: JobState) -> anyhow::Result<()> {
         let mut jobs = self.jobs.write().await;

--- a/src/mcp/job_manager.rs
+++ b/src/mcp/job_manager.rs
@@ -845,6 +845,47 @@ mod tests {
     use super::*;
     use tokio::process::Command;
 
+    fn spawn_cmd(program: &str, args: &[&str], piped: bool) -> tokio::process::Child {
+        let mut cmd = Command::new(program);
+        for arg in args {
+            cmd.arg(arg);
+        }
+        if piped {
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+        }
+        match cmd.spawn() {
+            Ok(child) => child,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                #[cfg(unix)]
+                {
+                    for path in &["/bin", "/usr/bin", "/usr/local/bin"] {
+                        let full_path = std::path::Path::new(path).join(program);
+                        let mut fallback_cmd = Command::new(&full_path);
+                        for arg in args {
+                            fallback_cmd.arg(arg);
+                        }
+                        if piped {
+                            fallback_cmd.stdout(std::process::Stdio::piped());
+                            fallback_cmd.stderr(std::process::Stdio::piped());
+                        }
+                        if let Ok(child) = fallback_cmd.spawn() {
+                            return child;
+                        }
+                    }
+                }
+                panic!(
+                    "Failed to spawn command '{}' with args {:?}: {:?}",
+                    program, args, e
+                );
+            }
+            Err(e) => panic!(
+                "Failed to spawn command '{}' with args {:?}: {:?}",
+                program, args, e
+            ),
+        }
+    }
+
     #[test]
     fn test_ring_buffer_basic() {
         let mut buffer = RingBuffer::new(3, 100);
@@ -918,12 +959,7 @@ mod tests {
         let manager = JobManager::new();
 
         // Create a simple command
-        let mut cmd = Command::new("echo");
-        cmd.arg("test");
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("echo", &["test"], true);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {
@@ -949,12 +985,7 @@ mod tests {
     async fn test_job_manager_get_job() {
         let manager = JobManager::new();
 
-        let mut cmd = Command::new("echo");
-        cmd.arg("test");
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("echo", &["test"], true);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {
@@ -982,12 +1013,7 @@ mod tests {
     async fn test_job_manager_add_output() {
         let manager = JobManager::new();
 
-        let mut cmd = Command::new("echo");
-        cmd.arg("test");
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("echo", &["test"], true);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {
@@ -1028,12 +1054,7 @@ mod tests {
             gc_interval_seconds: 0, // Run GC immediately
         });
 
-        let mut cmd = Command::new("echo");
-        cmd.arg("test");
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("echo", &["test"], true);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {
@@ -1067,12 +1088,7 @@ mod tests {
     async fn test_job_manager_records_completion_metadata() {
         let manager = JobManager::new();
 
-        let mut cmd = Command::new("echo");
-        cmd.arg("test");
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("echo", &["test"], true);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {
@@ -1102,12 +1118,7 @@ mod tests {
     async fn test_record_completed_job_rejects_overwriting_running_job() {
         let manager = JobManager::new();
 
-        let mut cmd = Command::new("sleep");
-        cmd.arg("5");
-        cmd.stdout(std::process::Stdio::piped());
-        cmd.stderr(std::process::Stdio::piped());
-
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("sleep", &["5"], true);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {
@@ -1148,9 +1159,7 @@ mod tests {
     async fn test_stop_job_graceful_managed_success() {
         let manager = JobManager::new();
 
-        let mut cmd = Command::new("sleep");
-        cmd.arg("10");
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("sleep", &["10"], false);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {
@@ -1183,7 +1192,7 @@ mod tests {
     async fn test_stop_job_graceful_fallback() {
         let manager = JobManager::new();
 
-        let mut child = tokio::process::Command::new("true").spawn().unwrap();
+        let mut child = spawn_cmd("true", &[], false);
         let pid = child.id().unwrap();
 
         // Wait for it to exit so it's fully reaped and no longer a zombie.
@@ -1229,20 +1238,9 @@ mod tests {
         let manager = JobManager::new();
 
         #[cfg(unix)]
-        let mut cmd = {
-            let mut cmd = Command::new("sh");
-            cmd.arg("-c");
-            cmd.arg("trap '' TERM; sleep 10");
-            cmd
-        };
+        let child = spawn_cmd("sh", &["-c", "trap '' TERM; sleep 10"], false);
         #[cfg(not(unix))]
-        let mut cmd = {
-            let mut cmd = Command::new("cmd");
-            cmd.arg("/c");
-            cmd.arg("ping 127.0.0.1 -n 10");
-            cmd
-        };
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("cmd", &["/c", "ping 127.0.0.1 -n 10"], false);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {
@@ -1282,8 +1280,7 @@ mod tests {
     async fn test_stop_job_graceful_already_exited() {
         let manager = JobManager::new();
 
-        let mut cmd = Command::new("echo");
-        let child = cmd.spawn().unwrap();
+        let child = spawn_cmd("echo", &[], false);
         let pid = child.id().unwrap();
 
         let metadata = JobMetadata {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -141,6 +141,7 @@ impl OutputNotificationBatch {
 
 #[derive(Debug, Clone)]
 struct CachedDiscoveredTasks {
+    root: PathBuf,
     discovered: task_discovery::DiscoveredTasks,
     cached_at: Instant,
 }
@@ -341,19 +342,21 @@ impl DelaMcpServer {
         &self.root
     }
 
-    async fn get_discovered_tasks(&self) -> task_discovery::DiscoveredTasks {
+    async fn get_discovered_tasks(&self, root: &PathBuf) -> task_discovery::DiscoveredTasks {
         {
             let cache = self.task_cache.read().await;
             if let Some(entry) = cache.as_ref()
+                && &entry.root == root
                 && entry.cached_at.elapsed() < self.task_cache_ttl
             {
                 return entry.discovered.clone();
             }
         }
 
-        let discovered = task_discovery::discover_tasks(&self.root);
+        let discovered = task_discovery::discover_tasks(root);
         let mut cache = self.task_cache.write().await;
         *cache = Some(CachedDiscoveredTasks {
+            root: root.clone(),
             discovered: discovered.clone(),
             cached_at: Instant::now(),
         });
@@ -384,7 +387,13 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<ListTasksArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let discovered = self.get_discovered_tasks().await;
+        let root_dir = if let Some(cwd) = &args.cwd {
+            PathBuf::from(cwd)
+        } else {
+            self.root.clone()
+        };
+
+        let discovered = self.get_discovered_tasks(&root_dir).await;
 
         // Apply runner filtering if specified
         let mut tasks = discovered.tasks;
@@ -429,7 +438,8 @@ impl DelaMcpServer {
 
         Ok(CallToolResult::success(vec![
             Content::json(serde_json::json!({
-                "running": running_jobs
+                "running": running_jobs,
+                "cwd": self.root.to_string_lossy().to_string()
             }))
             .expect("Failed to serialize JSON"),
         ]))
@@ -651,7 +661,13 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<TaskStartArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let discovered = self.get_discovered_tasks().await;
+        let root_dir = if let Some(cwd) = &args.cwd {
+            PathBuf::from(cwd)
+        } else {
+            self.root.clone()
+        };
+
+        let discovered = self.get_discovered_tasks(&root_dir).await;
 
         let task = discovered
             .tasks
@@ -1011,62 +1027,59 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<TaskStatusArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let jobs = self.job_manager.get_jobs_by_name(&args.unique_name).await;
-        let job_statuses: Vec<serde_json::Value> = jobs
-            .into_iter()
-            .map(|job| {
-                let mut status = "running";
-                let mut exit_code = None;
-                let mut signal = None;
-                let mut completed_at = None;
-                let mut error = None;
+        let job = self
+            .job_manager
+            .get_job(args.pid)
+            .await
+            .ok_or_else(|| DelaError::task_not_found(format!("Job with PID {} not found", args.pid)))?;
 
-                match &job.state {
-                    JobState::Running => {}
-                    JobState::Exited(code) => {
-                        status = "exited";
-                        exit_code = Some(*code);
-                        completed_at = job.completed_at;
-                    }
-                    JobState::Signaled(sig) => {
-                        status = "signaled";
-                        signal = Some(*sig);
-                        completed_at = job.completed_at;
-                    }
-                    JobState::Failed(msg) => {
-                        status = "failed";
-                        error = Some(msg.clone());
-                        completed_at = job.completed_at;
-                    }
-                }
+        let mut status = "running";
+        let mut exit_code = None;
+        let mut signal = None;
+        let mut completed_at = None;
+        let mut error = None;
 
-                let completed_at_str = completed_at
-                    .as_ref()
-                    .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Secs, true));
+        match &job.state {
+            JobState::Running => {}
+            JobState::Exited(code) => {
+                status = "exited";
+                exit_code = Some(*code);
+                completed_at = job.completed_at;
+            }
+            JobState::Signaled(sig) => {
+                status = "signaled";
+                signal = Some(*sig);
+                completed_at = job.completed_at;
+            }
+            JobState::Failed(msg) => {
+                status = "failed";
+                error = Some(msg.clone());
+                completed_at = job.completed_at;
+            }
+        }
 
-                serde_json::json!({
-                    "pid": job.pid,
-                    "unique_name": job.metadata.unique_name,
-                    "source_name": job.metadata.source_name,
-                    "state": status,
-                    "error": error,
-                    "exit_code": exit_code,
-                    "signal": signal,
-                    "elapsed_seconds": job.age().as_secs(),
-                    "completed_at": completed_at_str,
-                    "command": job.metadata.command,
-                    "file_path": job.metadata.file_path.to_string_lossy(),
-                    "args": job.metadata.args,
-                    "cwd": job.metadata.cwd.map(|p| p.to_string_lossy().to_string())
-                })
-            })
-            .collect();
+        let completed_at_str = completed_at
+            .as_ref()
+            .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Secs, true));
+
+        let job_status = serde_json::json!({
+            "pid": job.pid,
+            "unique_name": job.metadata.unique_name,
+            "source_name": job.metadata.source_name,
+            "state": status,
+            "error": error,
+            "exit_code": exit_code,
+            "signal": signal,
+            "elapsed_seconds": job.age().as_secs(),
+            "completed_at": completed_at_str,
+            "command": job.metadata.command,
+            "file_path": job.metadata.file_path.to_string_lossy(),
+            "args": job.metadata.args,
+            "cwd": job.metadata.cwd.map(|p| p.to_string_lossy().to_string())
+        });
 
         Ok(CallToolResult::success(vec![
-            Content::json(serde_json::json!({
-                "jobs": job_statuses
-            }))
-            .expect("Failed to serialize JSON"),
+            Content::json(job_status).expect("Failed to serialize JSON"),
         ]))
     }
 
@@ -1385,6 +1398,16 @@ impl ServerHandler for DelaMcpServer {
             serde_json::Value::String("Optional runner filter".to_string()),
         );
         list_tasks_properties.insert("runner".to_string(), serde_json::Value::Object(runner_prop));
+        let mut list_tasks_cwd_prop = Map::new();
+        list_tasks_cwd_prop.insert(
+            "type".to_string(),
+            serde_json::Value::String("string".to_string()),
+        );
+        list_tasks_cwd_prop.insert(
+            "description".to_string(),
+            serde_json::Value::String("Optional working directory to discover tasks in".to_string()),
+        );
+        list_tasks_properties.insert("cwd".to_string(), serde_json::Value::Object(list_tasks_cwd_prop));
         list_tasks_schema.insert(
             "properties".to_string(),
             serde_json::Value::Object(list_tasks_properties),
@@ -1525,18 +1548,18 @@ impl ServerHandler for DelaMcpServer {
             serde_json::Value::String("object".to_string()),
         );
         let mut task_status_properties = Map::new();
-        let mut task_status_unique_name_prop = Map::new();
-        task_status_unique_name_prop.insert(
+        let mut task_status_pid_prop = Map::new();
+        task_status_pid_prop.insert(
             "type".to_string(),
-            serde_json::Value::String("string".to_string()),
+            serde_json::Value::String("integer".to_string()),
         );
-        task_status_unique_name_prop.insert(
+        task_status_pid_prop.insert(
             "description".to_string(),
-            serde_json::Value::String("The unique name of the task to get status for".to_string()),
+            serde_json::Value::String("The PID of the job to get status for".to_string()),
         );
         task_status_properties.insert(
-            "unique_name".to_string(),
-            serde_json::Value::Object(task_status_unique_name_prop),
+            "pid".to_string(),
+            serde_json::Value::Object(task_status_pid_prop),
         );
         task_status_schema.insert(
             "properties".to_string(),
@@ -1544,7 +1567,7 @@ impl ServerHandler for DelaMcpServer {
         );
         task_status_schema.insert(
             "required".to_string(),
-            serde_json::Value::Array(vec![serde_json::Value::String("unique_name".to_string())]),
+            serde_json::Value::Array(vec![serde_json::Value::String("pid".to_string())]),
         );
 
         // Schema for task_output
@@ -1753,7 +1776,7 @@ mod tests {
 
         // Test that the new tools work with proper arguments
         let status_args = TaskStatusArgs {
-            unique_name: "test-task".to_string(),
+            pid: 12345,
         };
         let output_args = TaskOutputArgs {
             pid: 12345,
@@ -1766,9 +1789,8 @@ mod tests {
             grace_period: None,
         };
 
-        // These should work (even if they return empty results for non-existent jobs)
-        assert!(server.task_status(Parameters(status_args)).await.is_ok());
-        // task_output and task_stop should return errors for non-existent jobs
+        // task_status, task_output and task_stop should return errors for non-existent jobs
+        assert!(server.task_status(Parameters(status_args)).await.is_err());
         assert!(server.task_output(Parameters(output_args)).await.is_err());
         assert!(server.task_stop(Parameters(stop_args)).await.is_err());
 
@@ -1868,29 +1890,14 @@ mod tests {
         let temp_dir = std::env::temp_dir();
         let server = DelaMcpServer::new(temp_dir);
         let args = TaskStatusArgs {
-            unique_name: "nonexistent-task".to_string(),
+            pid: 99999,
         };
 
         // Act
-        let result = server.task_status(Parameters(args)).await.unwrap();
+        let result = server.task_status(Parameters(args)).await;
 
         // Assert
-        assert_eq!(result.content.len(), 1);
-        let content = &result.content[0];
-        match &content.raw {
-            RawContent::Text(text_content) => {
-                let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
-                let obj = json.as_object().unwrap();
-                assert!(obj.contains_key("jobs"));
-                let jobs = obj["jobs"].as_array().unwrap();
-                assert_eq!(
-                    jobs.len(),
-                    0,
-                    "Should return empty array for nonexistent task"
-                );
-            }
-            _ => panic!("Expected text content with JSON"),
-        }
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -1899,10 +1906,9 @@ mod tests {
         let temp_dir = std::env::temp_dir();
         let server = DelaMcpServer::new(temp_dir);
 
-        // Create multiple jobs with the same unique_name
         let metadata1 = JobMetadata {
             started_at: std::time::Instant::now(),
-            unique_name: "test-task".to_string(),
+            unique_name: "test-task1".to_string(),
             source_name: "test".to_string(),
             args: Some(vec!["--verbose".to_string()]),
             env: None,
@@ -1913,7 +1919,7 @@ mod tests {
 
         let metadata2 = JobMetadata {
             started_at: std::time::Instant::now(),
-            unique_name: "test-task".to_string(),
+            unique_name: "test-task2".to_string(),
             source_name: "test".to_string(),
             args: Some(vec!["--quiet".to_string()]),
             env: None,
@@ -1948,40 +1954,30 @@ mod tests {
             .await
             .unwrap();
 
-        let args = TaskStatusArgs {
-            unique_name: "test-task".to_string(),
-        };
-
-        // Act
-        let result = server.task_status(Parameters(args)).await.unwrap();
-
-        // Assert
-        assert_eq!(result.content.len(), 1);
-        let content = &result.content[0];
-        match &content.raw {
+        // Act & Assert for job 1
+        let result1 = server.task_status(Parameters(TaskStatusArgs { pid: pid1 })).await.unwrap();
+        assert_eq!(result1.content.len(), 1);
+        match &result1.content[0].raw {
             RawContent::Text(text_content) => {
-                let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
-                let obj = json.as_object().unwrap();
-                assert!(obj.contains_key("jobs"));
-                let jobs = obj["jobs"].as_array().unwrap();
-                assert_eq!(
-                    jobs.len(),
-                    2,
-                    "Should return two jobs for the same unique_name"
-                );
-
-                // Check that both jobs have the correct unique_name
-                for job in jobs {
-                    assert_eq!(job["unique_name"], "test-task");
-                    assert_eq!(job["source_name"], "test");
-                    assert!(job["pid"].is_number());
-                    assert!(job["state"].is_string());
-                    assert_eq!(job["state"], "running");
-                    assert!(job["exit_code"].is_null());
-                    assert!(job["completed_at"].is_null());
-                }
+                let job: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
+                assert_eq!(job["unique_name"], "test-task1");
+                assert_eq!(job["pid"], pid1);
+                assert_eq!(job["state"], "running");
             }
-            _ => panic!("Expected text content with JSON"),
+            _ => panic!("Expected text content"),
+        }
+
+        // Act & Assert for job 2
+        let result2 = server.task_status(Parameters(TaskStatusArgs { pid: pid2 })).await.unwrap();
+        assert_eq!(result2.content.len(), 1);
+        match &result2.content[0].raw {
+            RawContent::Text(text_content) => {
+                let job: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
+                assert_eq!(job["unique_name"], "test-task2");
+                assert_eq!(job["pid"], pid2);
+                assert_eq!(job["state"], "running");
+            }
+            _ => panic!("Expected text content"),
         }
     }
 
@@ -2025,7 +2021,7 @@ mod tests {
             .unwrap();
 
         let args = TaskStatusArgs {
-            unique_name: "test-task".to_string(),
+            pid,
         };
 
         // Act
@@ -2036,13 +2032,7 @@ mod tests {
         let content = &result.content[0];
         match &content.raw {
             RawContent::Text(text_content) => {
-                let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
-                let obj = json.as_object().unwrap();
-                assert!(obj.contains_key("jobs"));
-                let jobs = obj["jobs"].as_array().unwrap();
-                assert_eq!(jobs.len(), 1, "Should return one job");
-
-                let job = &jobs[0];
+                let job: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
                 assert_eq!(job["unique_name"], "test-task");
                 assert_eq!(job["state"], "exited");
                 assert_eq!(job["exit_code"], 0);
@@ -2088,7 +2078,7 @@ mod tests {
 
         let result = server
             .task_status(Parameters(TaskStatusArgs {
-                unique_name: "test-task".to_string(),
+                pid,
             }))
             .await
             .unwrap();
@@ -2096,12 +2086,10 @@ mod tests {
         let content = &result.content[0];
         match &content.raw {
             RawContent::Text(text_content) => {
-                let json: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
-                let jobs = json["jobs"].as_array().unwrap();
-                assert_eq!(jobs.len(), 1);
-                assert_eq!(jobs[0]["state"], "failed");
-                assert!(jobs[0]["exit_code"].is_null());
-                assert!(jobs[0]["completed_at"].is_string());
+                let job: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
+                assert_eq!(job["state"], "failed");
+                assert!(job["exit_code"].is_null());
+                assert!(job["completed_at"].is_string());
             }
             _ => panic!("Expected text content with JSON"),
         }
@@ -2922,6 +2910,7 @@ test:
         // Act & Assert - Test filtering by "make"
         let make_args = Parameters(ListTasksArgs {
             runner: Some("make".to_string()),
+            cwd: None,
         });
         let make_result = server.list_tasks(make_args).await.unwrap();
         assert_eq!(make_result.content.len(), 1);
@@ -2929,6 +2918,7 @@ test:
         // Act & Assert - Test filtering by "npm"
         let npm_args = Parameters(ListTasksArgs {
             runner: Some("npm".to_string()),
+            cwd: None,
         });
         let npm_result = server.list_tasks(npm_args).await.unwrap();
         assert_eq!(npm_result.content.len(), 1);
@@ -2936,6 +2926,7 @@ test:
         // Act & Assert - Test filtering by non-existent runner
         let nonexistent_args = Parameters(ListTasksArgs {
             runner: Some("nonexistent".to_string()),
+            cwd: None,
         });
         let nonexistent_result = server.list_tasks(nonexistent_args).await.unwrap();
         assert_eq!(nonexistent_result.content.len(), 1);
@@ -2967,6 +2958,7 @@ test:
         // Act & Assert - Test exact match
         let exact_args = Parameters(ListTasksArgs {
             runner: Some("make".to_string()),
+            cwd: None,
         });
         let exact_result = server.list_tasks(exact_args).await.unwrap();
         assert_eq!(exact_result.content.len(), 1);
@@ -2974,6 +2966,7 @@ test:
         // Act & Assert - Test case mismatch (should return empty)
         let case_args = Parameters(ListTasksArgs {
             runner: Some("MAKE".to_string()),
+            cwd: None,
         });
         let case_result = server.list_tasks(case_args).await.unwrap();
         assert_eq!(case_result.content.len(), 1);
@@ -3535,9 +3528,13 @@ add_custom_target(build-all COMMENT "Build everything")
         };
         assert_eq!(status_json["running"].as_array().unwrap().len(), 0);
 
+        let completed_jobs = server.job_manager.get_all_jobs().await;
+        let job = completed_jobs.iter().find(|j| j.metadata.unique_name == "waited_task").unwrap();
+        let pid = job.pid;
+
         let task_status_result = server
             .task_status(Parameters(TaskStatusArgs {
-                unique_name: "waited_task".to_string(),
+                pid,
             }))
             .await
             .unwrap();
@@ -3547,15 +3544,13 @@ add_custom_target(build-all COMMENT "Build everything")
             }
             _ => panic!("Expected text content"),
         };
-        let jobs = task_status_json["jobs"].as_array().unwrap();
-        assert_eq!(jobs.len(), 1);
-        assert_eq!(jobs[0]["state"], "exited");
+        assert_eq!(task_status_json["state"], "exited");
 
         sleep(Duration::from_secs(2)).await;
 
         let task_status_result_later = server
             .task_status(Parameters(TaskStatusArgs {
-                unique_name: "waited_task".to_string(),
+                pid,
             }))
             .await
             .unwrap();
@@ -3565,8 +3560,7 @@ add_custom_target(build-all COMMENT "Build everything")
             }
             _ => panic!("Expected text content"),
         };
-        let later_job = &task_status_json_later["jobs"].as_array().unwrap()[0];
-        let elapsed_seconds = later_job["elapsed_seconds"].as_u64().unwrap();
+        let elapsed_seconds = task_status_json_later["elapsed_seconds"].as_u64().unwrap();
         assert!(
             (1..=2).contains(&elapsed_seconds),
             "completed task elapsed_seconds should reflect its actual runtime, got {}",
@@ -3640,7 +3634,7 @@ add_custom_target(build-all COMMENT "Build everything")
 
         let task_status_result = server
             .task_status(Parameters(TaskStatusArgs {
-                unique_name: "still_running_task".to_string(),
+                pid,
             }))
             .await
             .unwrap();
@@ -3650,10 +3644,9 @@ add_custom_target(build-all COMMENT "Build everything")
             }
             _ => panic!("Expected text content"),
         };
-        let running_job = &task_status_json["jobs"].as_array().unwrap()[0];
-        assert_eq!(running_job["state"], "running");
+        assert_eq!(task_status_json["state"], "running");
         assert!(
-            running_job["elapsed_seconds"].as_u64().unwrap() >= 2,
+            task_status_json["elapsed_seconds"].as_u64().unwrap() >= 2,
             "elapsed_seconds should include the initial bounded wait window"
         );
 
@@ -3785,7 +3778,7 @@ add_custom_target(build-all COMMENT "Build everything")
 
                 // Check task_status immediately - should show as running
                 let task_status_args = TaskStatusArgs {
-                    unique_name: "long_task".to_string(),
+                    pid,
                 };
                 let task_status_result = server
                     .task_status(Parameters(task_status_args))
@@ -3796,17 +3789,12 @@ add_custom_target(build-all COMMENT "Build everything")
                     RawContent::Text(text_content) => {
                         let task_status_json: serde_json::Value =
                             serde_json::from_str(&text_content.text).unwrap();
-                        let jobs = task_status_json["jobs"].as_array().unwrap();
                         println!(
-                            "Task status immediately after start: {} jobs, first job state: {}",
-                            jobs.len(),
-                            jobs.first()
-                                .map(|j| j["state"].as_str().unwrap_or("unknown"))
-                                .unwrap_or("none")
+                            "Task status immediately after start: {}",
+                            task_status_json["state"].as_str().unwrap_or("unknown")
                         );
-                        assert_eq!(jobs.len(), 1, "Should have 1 job");
-                        assert_eq!(jobs[0]["state"].as_str().unwrap(), "running");
-                        assert_eq!(jobs[0]["pid"].as_i64().unwrap() as u32, pid);
+                        assert_eq!(task_status_json["state"].as_str().unwrap(), "running");
+                        assert_eq!(task_status_json["pid"].as_i64().unwrap() as u32, pid);
                     }
                     _ => panic!("Expected text content"),
                 }
@@ -3857,7 +3845,7 @@ add_custom_target(build-all COMMENT "Build everything")
 
                 // Check task_status after completion - should show as exited
                 let task_status_args_final = TaskStatusArgs {
-                    unique_name: "long_task".to_string(),
+                    pid,
                 };
                 let task_status_result_final = server
                     .task_status(Parameters(task_status_args_final))
@@ -3868,17 +3856,12 @@ add_custom_target(build-all COMMENT "Build everything")
                     RawContent::Text(text_content) => {
                         let task_status_json: serde_json::Value =
                             serde_json::from_str(&text_content.text).unwrap();
-                        let jobs = task_status_json["jobs"].as_array().unwrap();
                         println!(
-                            "Task status after completion: {} jobs, first job state: {}",
-                            jobs.len(),
-                            jobs.first()
-                                .map(|j| j["state"].as_str().unwrap_or("unknown"))
-                                .unwrap_or("none")
+                            "Task status after completion: {}",
+                            task_status_json["state"].as_str().unwrap_or("unknown")
                         );
-                        assert_eq!(jobs.len(), 1, "Should still have 1 job record");
-                        assert_eq!(jobs[0]["state"].as_str().unwrap(), "exited");
-                        assert_eq!(jobs[0]["pid"].as_i64().unwrap() as u32, pid);
+                        assert_eq!(task_status_json["state"].as_str().unwrap(), "exited");
+                        assert_eq!(task_status_json["pid"].as_i64().unwrap() as u32, pid);
                     }
                     _ => panic!("Expected text content"),
                 }
@@ -3978,9 +3961,18 @@ add_custom_target(build-all COMMENT "Build everything")
             _ => panic!("Expected text content"),
         }
 
+        let pid = server
+            .job_manager
+            .get_all_jobs()
+            .await
+            .iter()
+            .find(|job| job.metadata.unique_name == "bg-test")
+            .map(|job| job.pid)
+            .expect("Should have recorded the job");
+
         // task_status should record the job as exited quickly
         let task_status_args = TaskStatusArgs {
-            unique_name: "bg-test".to_string(),
+            pid,
         };
         let task_status_result = server
             .task_status(Parameters(task_status_args))
@@ -3989,11 +3981,8 @@ add_custom_target(build-all COMMENT "Build everything")
         let task_status_content = &task_status_result.content[0];
         match &task_status_content.raw {
             RawContent::Text(text_content) => {
-                let task_status_json: serde_json::Value =
+                let job: serde_json::Value =
                     serde_json::from_str(&text_content.text).unwrap();
-                let jobs = task_status_json["jobs"].as_array().unwrap();
-                assert!(!jobs.is_empty());
-                let job = &jobs[0];
                 assert_eq!(job["state"].as_str().unwrap(), "exited");
                 if start_state == "running" {
                     assert!(job["pid"].is_number());
@@ -4298,13 +4287,10 @@ add_custom_target(build-all COMMENT "Build everything")
         let context = RequestContext::new(RequestId::Number(1), running_server.peer().clone());
 
         let mut args = serde_json::Map::new();
-        args.insert(
-            "unique_name".to_string(),
-            serde_json::Value::String("nonexistent".to_string()),
-        );
+        args.insert("pid".to_string(), serde_json::Value::Number(12345.into()));
         let req = CallToolRequestParams::new("task_status").with_arguments(args);
         let res = server.call_tool(req, context).await;
-        assert!(res.is_ok());
+        assert!(res.is_err());
     }
 
     #[tokio::test]

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -186,16 +186,31 @@ impl DelaMcpServer {
 
     /// Create a new MCP server instance with a custom allowlist evaluator (for testing)
     #[cfg(test)]
-    pub fn new_with_allowlist(root: PathBuf, allowlist_evaluator: McpAllowlistEvaluator) -> Self {
+    pub fn new_with_allowlist(
+        root: PathBuf,
+        mut allowlist_evaluator: McpAllowlistEvaluator,
+    ) -> Self {
+        for entry in &mut allowlist_evaluator.allowlist.entries {
+            if let Ok(canon) = entry.path.canonicalize() {
+                entry.path = canon;
+            }
+        }
+        let root = root.canonicalize().unwrap_or(root);
         Self::new_inner(root, allowlist_evaluator, TASK_DISCOVERY_CACHE_TTL)
     }
 
     #[cfg(test)]
     pub fn new_with_allowlist_and_cache_ttl(
         root: PathBuf,
-        allowlist_evaluator: McpAllowlistEvaluator,
+        mut allowlist_evaluator: McpAllowlistEvaluator,
         task_cache_ttl: Duration,
     ) -> Self {
+        for entry in &mut allowlist_evaluator.allowlist.entries {
+            if let Ok(canon) = entry.path.canonicalize() {
+                entry.path = canon;
+            }
+        }
+        let root = root.canonicalize().unwrap_or(root);
         Self::new_inner(root, allowlist_evaluator, task_cache_ttl)
     }
 
@@ -370,7 +385,10 @@ impl DelaMcpServer {
     /// Returns `self.root` when `cwd` is `None`.
     fn resolve_requested_cwd(&self, cwd: &Option<String>) -> Result<PathBuf, ErrorData> {
         let Some(raw) = cwd else {
-            return Ok(self.root.clone());
+            return self.root.canonicalize().map_err(|e| {
+                DelaError::internal_error(format!("Cannot canonicalize server root: {}", e), None)
+                    .into()
+            });
         };
 
         let candidate = if Path::new(raw).is_absolute() {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -345,10 +345,11 @@ impl DelaMcpServer {
     async fn get_discovered_tasks(&self, root: &PathBuf) -> task_discovery::DiscoveredTasks {
         {
             let cache = self.task_cache.read().await;
-            if let Some(entry) = cache.get(root) {
-                if entry.cached_at.elapsed() < self.task_cache_ttl {
-                    return entry.discovered.clone();
-                }
+            if let Some(entry) = cache
+                .get(root)
+                .filter(|entry| entry.cached_at.elapsed() < self.task_cache_ttl)
+            {
+                return entry.discovered.clone();
             }
         }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1741,7 +1741,7 @@ impl ServerHandler for DelaMcpServer {
             ),
             Tool::new_with_raw(
                 "task_status",
-                Some("Status for a single unique_name (may have multiple PIDs)".into()),
+                Some("Get the status of a single job by its PID".into()),
                 task_status_schema,
             ),
             Tool::new_with_raw(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -15,7 +15,7 @@ use rmcp::{
     service::{Peer, RequestContext, RoleServer},
     tool,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, BufReader, stdin, stdout};
@@ -363,6 +363,49 @@ impl DelaMcpServer {
         discovered
     }
 
+    /// Resolve a caller-supplied `cwd` to a canonical path, ensuring it stays
+    /// within `self.root`.  Relative paths are resolved against `self.root`.
+    /// Returns `self.root` when `cwd` is `None`.
+    fn resolve_requested_cwd(&self, cwd: &Option<String>) -> Result<PathBuf, ErrorData> {
+        let Some(raw) = cwd else {
+            return Ok(self.root.clone());
+        };
+
+        let candidate = if Path::new(raw).is_absolute() {
+            PathBuf::from(raw)
+        } else {
+            self.root.join(raw)
+        };
+
+        // Canonicalize both so symlinks and `..` are resolved.
+        let canonical = candidate.canonicalize().map_err(|e| {
+            DelaError::internal_error(
+                format!("Invalid cwd '{}': {}", raw, e),
+                Some(
+                    "Provide an absolute path or a relative path within the workspace".to_string(),
+                ),
+            )
+        })?;
+
+        let root_canonical = self.root.canonicalize().map_err(|e| {
+            DelaError::internal_error(format!("Cannot canonicalize server root: {}", e), None)
+        })?;
+
+        if !canonical.starts_with(&root_canonical) {
+            return Err(DelaError::internal_error(
+                format!(
+                    "Requested cwd '{}' is outside the workspace root '{}'",
+                    raw,
+                    self.root.display()
+                ),
+                Some("cwd must be within the workspace root".to_string()),
+            )
+            .into());
+        }
+
+        Ok(canonical)
+    }
+
     /// Start an MCP stdio server and block until shutdown.
     /// IMPORTANT: Do not print to stdout; MCP JSON-RPC uses stdout.
     pub async fn serve_stdio(self) -> Result<(), ErrorData> {
@@ -387,11 +430,7 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<ListTasksArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let root_dir = if let Some(cwd) = &args.cwd {
-            PathBuf::from(cwd)
-        } else {
-            self.root.clone()
-        };
+        let root_dir = self.resolve_requested_cwd(&args.cwd)?;
 
         let discovered = self.get_discovered_tasks(&root_dir).await;
 
@@ -661,11 +700,7 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<TaskStartArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let root_dir = if let Some(cwd) = &args.cwd {
-            PathBuf::from(cwd)
-        } else {
-            self.root.clone()
-        };
+        let root_dir = self.resolve_requested_cwd(&args.cwd)?;
 
         let discovered = self.get_discovered_tasks(&root_dir).await;
 
@@ -732,7 +767,7 @@ impl DelaMcpServer {
         let base_args: Vec<&String> = command_iter.collect();
 
         let mut cmd = Command::new(executable);
-        cmd.current_dir(self.root.clone());
+        cmd.current_dir(&root_dir);
 
         // Ensure we capture stdout and stderr properly
         cmd.stdout(std::process::Stdio::piped());
@@ -751,11 +786,6 @@ impl DelaMcpServer {
             for (key, value) in env_vars {
                 cmd.env(key, value);
             }
-        }
-
-        // Set working directory if specified
-        if let Some(cwd) = &args.cwd {
-            cmd.current_dir(cwd);
         }
 
         let started_at = Instant::now();
@@ -885,7 +915,7 @@ impl DelaMcpServer {
                 source_name: task.source_name.clone(),
                 args: args.args.clone(),
                 env: args.env.clone(),
-                cwd: args.cwd.as_ref().map(PathBuf::from),
+                cwd: Some(root_dir.clone()),
                 command: task.runner.get_command(task),
                 file_path: task.definition_path().to_path_buf(),
             };
@@ -961,7 +991,7 @@ impl DelaMcpServer {
             source_name: task.source_name.clone(),
             args: args.args.clone(),
             env: args.env.clone(),
-            cwd: args.cwd.as_ref().map(PathBuf::from),
+            cwd: Some(root_dir.clone()),
             command: task.runner.get_command(task),
             file_path: task.definition_path().to_path_buf(),
         };
@@ -1027,9 +1057,11 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<TaskStatusArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let job = self.job_manager.get_job(args.pid).await.ok_or_else(|| {
-            DelaError::task_not_found(format!("Job with PID {} not found", args.pid))
-        })?;
+        let job = self
+            .job_manager
+            .get_job(args.pid)
+            .await
+            .ok_or_else(|| DelaError::job_not_found(args.pid))?;
 
         let mut status = "running";
         let mut exit_code = None;
@@ -1090,7 +1122,7 @@ impl DelaMcpServer {
             .job_manager
             .get_job(args.pid)
             .await
-            .ok_or_else(|| DelaError::task_not_found(format!("Job with PID {}", args.pid)))?;
+            .ok_or_else(|| DelaError::job_not_found(args.pid))?;
 
         let requested_lines = args.lines.unwrap_or(200);
         let total_lines = job.output_buffer.len();
@@ -1221,7 +1253,7 @@ impl DelaMcpServer {
             .job_manager
             .get_job(args.pid)
             .await
-            .ok_or_else(|| DelaError::task_not_found(format!("Job with PID {}", args.pid)))?;
+            .ok_or_else(|| DelaError::job_not_found(args.pid))?;
 
         if !job.is_running() {
             return Err(DelaError::internal_error(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -15,6 +15,7 @@ use rmcp::{
     service::{Peer, RequestContext, RoleServer},
     tool,
 };
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
@@ -141,7 +142,6 @@ impl OutputNotificationBatch {
 
 #[derive(Debug, Clone)]
 struct CachedDiscoveredTasks {
-    root: PathBuf,
     discovered: task_discovery::DiscoveredTasks,
     cached_at: Instant,
 }
@@ -152,7 +152,7 @@ pub struct DelaMcpServer {
     root: PathBuf,
     allowlist_evaluator: McpAllowlistEvaluator,
     job_manager: JobManager,
-    task_cache: Arc<RwLock<Option<CachedDiscoveredTasks>>>,
+    task_cache: Arc<RwLock<HashMap<PathBuf, CachedDiscoveredTasks>>>,
     task_cache_ttl: Duration,
     /// Peer connection for sending notifications (set during initialize)
     peer: Arc<OnceCell<Peer<RoleServer>>>,
@@ -178,7 +178,7 @@ impl DelaMcpServer {
             root,
             allowlist_evaluator,
             job_manager,
-            task_cache: Arc::new(RwLock::new(None)),
+            task_cache: Arc::new(RwLock::new(HashMap::new())),
             task_cache_ttl,
             peer: Arc::new(OnceCell::new()),
         }
@@ -345,21 +345,22 @@ impl DelaMcpServer {
     async fn get_discovered_tasks(&self, root: &PathBuf) -> task_discovery::DiscoveredTasks {
         {
             let cache = self.task_cache.read().await;
-            if let Some(entry) = cache.as_ref()
-                && &entry.root == root
-                && entry.cached_at.elapsed() < self.task_cache_ttl
-            {
-                return entry.discovered.clone();
+            if let Some(entry) = cache.get(root) {
+                if entry.cached_at.elapsed() < self.task_cache_ttl {
+                    return entry.discovered.clone();
+                }
             }
         }
 
         let discovered = task_discovery::discover_tasks(root);
         let mut cache = self.task_cache.write().await;
-        *cache = Some(CachedDiscoveredTasks {
-            root: root.clone(),
-            discovered: discovered.clone(),
-            cached_at: Instant::now(),
-        });
+        cache.insert(
+            root.clone(),
+            CachedDiscoveredTasks {
+                discovered: discovered.clone(),
+                cached_at: Instant::now(),
+            },
+        );
         discovered
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1027,11 +1027,9 @@ impl DelaMcpServer {
         &self,
         Parameters(args): Parameters<TaskStatusArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let job = self
-            .job_manager
-            .get_job(args.pid)
-            .await
-            .ok_or_else(|| DelaError::task_not_found(format!("Job with PID {} not found", args.pid)))?;
+        let job = self.job_manager.get_job(args.pid).await.ok_or_else(|| {
+            DelaError::task_not_found(format!("Job with PID {} not found", args.pid))
+        })?;
 
         let mut status = "running";
         let mut exit_code = None;
@@ -1405,9 +1403,14 @@ impl ServerHandler for DelaMcpServer {
         );
         list_tasks_cwd_prop.insert(
             "description".to_string(),
-            serde_json::Value::String("Optional working directory to discover tasks in".to_string()),
+            serde_json::Value::String(
+                "Optional working directory to discover tasks in".to_string(),
+            ),
         );
-        list_tasks_properties.insert("cwd".to_string(), serde_json::Value::Object(list_tasks_cwd_prop));
+        list_tasks_properties.insert(
+            "cwd".to_string(),
+            serde_json::Value::Object(list_tasks_cwd_prop),
+        );
         list_tasks_schema.insert(
             "properties".to_string(),
             serde_json::Value::Object(list_tasks_properties),
@@ -1775,9 +1778,7 @@ mod tests {
         let server = DelaMcpServer::new(PathBuf::from("."));
 
         // Test that the new tools work with proper arguments
-        let status_args = TaskStatusArgs {
-            pid: 12345,
-        };
+        let status_args = TaskStatusArgs { pid: 12345 };
         let output_args = TaskOutputArgs {
             pid: 12345,
             lines: Some(10),
@@ -1889,9 +1890,7 @@ mod tests {
         // Arrange
         let temp_dir = std::env::temp_dir();
         let server = DelaMcpServer::new(temp_dir);
-        let args = TaskStatusArgs {
-            pid: 99999,
-        };
+        let args = TaskStatusArgs { pid: 99999 };
 
         // Act
         let result = server.task_status(Parameters(args)).await;
@@ -1955,7 +1954,10 @@ mod tests {
             .unwrap();
 
         // Act & Assert for job 1
-        let result1 = server.task_status(Parameters(TaskStatusArgs { pid: pid1 })).await.unwrap();
+        let result1 = server
+            .task_status(Parameters(TaskStatusArgs { pid: pid1 }))
+            .await
+            .unwrap();
         assert_eq!(result1.content.len(), 1);
         match &result1.content[0].raw {
             RawContent::Text(text_content) => {
@@ -1968,7 +1970,10 @@ mod tests {
         }
 
         // Act & Assert for job 2
-        let result2 = server.task_status(Parameters(TaskStatusArgs { pid: pid2 })).await.unwrap();
+        let result2 = server
+            .task_status(Parameters(TaskStatusArgs { pid: pid2 }))
+            .await
+            .unwrap();
         assert_eq!(result2.content.len(), 1);
         match &result2.content[0].raw {
             RawContent::Text(text_content) => {
@@ -2020,9 +2025,7 @@ mod tests {
             .await
             .unwrap();
 
-        let args = TaskStatusArgs {
-            pid,
-        };
+        let args = TaskStatusArgs { pid };
 
         // Act
         let result = server.task_status(Parameters(args)).await.unwrap();
@@ -2077,9 +2080,7 @@ mod tests {
             .unwrap();
 
         let result = server
-            .task_status(Parameters(TaskStatusArgs {
-                pid,
-            }))
+            .task_status(Parameters(TaskStatusArgs { pid }))
             .await
             .unwrap();
 
@@ -3529,13 +3530,14 @@ add_custom_target(build-all COMMENT "Build everything")
         assert_eq!(status_json["running"].as_array().unwrap().len(), 0);
 
         let completed_jobs = server.job_manager.get_all_jobs().await;
-        let job = completed_jobs.iter().find(|j| j.metadata.unique_name == "waited_task").unwrap();
+        let job = completed_jobs
+            .iter()
+            .find(|j| j.metadata.unique_name == "waited_task")
+            .unwrap();
         let pid = job.pid;
 
         let task_status_result = server
-            .task_status(Parameters(TaskStatusArgs {
-                pid,
-            }))
+            .task_status(Parameters(TaskStatusArgs { pid }))
             .await
             .unwrap();
         let task_status_json = match &task_status_result.content[0].raw {
@@ -3549,9 +3551,7 @@ add_custom_target(build-all COMMENT "Build everything")
         sleep(Duration::from_secs(2)).await;
 
         let task_status_result_later = server
-            .task_status(Parameters(TaskStatusArgs {
-                pid,
-            }))
+            .task_status(Parameters(TaskStatusArgs { pid }))
             .await
             .unwrap();
         let task_status_json_later = match &task_status_result_later.content[0].raw {
@@ -3633,9 +3633,7 @@ add_custom_target(build-all COMMENT "Build everything")
         assert_eq!(status_json["running"].as_array().unwrap().len(), 1);
 
         let task_status_result = server
-            .task_status(Parameters(TaskStatusArgs {
-                pid,
-            }))
+            .task_status(Parameters(TaskStatusArgs { pid }))
             .await
             .unwrap();
         let task_status_json = match &task_status_result.content[0].raw {
@@ -3777,9 +3775,7 @@ add_custom_target(build-all COMMENT "Build everything")
                 }
 
                 // Check task_status immediately - should show as running
-                let task_status_args = TaskStatusArgs {
-                    pid,
-                };
+                let task_status_args = TaskStatusArgs { pid };
                 let task_status_result = server
                     .task_status(Parameters(task_status_args))
                     .await
@@ -3844,9 +3840,7 @@ add_custom_target(build-all COMMENT "Build everything")
                 }
 
                 // Check task_status after completion - should show as exited
-                let task_status_args_final = TaskStatusArgs {
-                    pid,
-                };
+                let task_status_args_final = TaskStatusArgs { pid };
                 let task_status_result_final = server
                     .task_status(Parameters(task_status_args_final))
                     .await
@@ -3971,9 +3965,7 @@ add_custom_target(build-all COMMENT "Build everything")
             .expect("Should have recorded the job");
 
         // task_status should record the job as exited quickly
-        let task_status_args = TaskStatusArgs {
-            pid,
-        };
+        let task_status_args = TaskStatusArgs { pid };
         let task_status_result = server
             .task_status(Parameters(task_status_args))
             .await
@@ -3981,8 +3973,7 @@ add_custom_target(build-all COMMENT "Build everything")
         let task_status_content = &task_status_result.content[0];
         match &task_status_content.raw {
             RawContent::Text(text_content) => {
-                let job: serde_json::Value =
-                    serde_json::from_str(&text_content.text).unwrap();
+                let job: serde_json::Value = serde_json::from_str(&text_content.text).unwrap();
                 assert_eq!(job["state"].as_str().unwrap(), "exited");
                 if start_state == "running" {
                     assert!(job["pid"].is_number());

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -284,7 +284,7 @@ def test_list_tasks_cwd():
         # Check listing with empty directory cwd
         response_empty, _ = send_request(
             process,
-            tool_request(32, "list_tasks", {"cwd": "/home/testuser/.config/dela"}),
+            tool_request(32, "list_tasks", {"cwd": "/home/testuser/test_project/assets_py"}),
         )
         payload_empty = parse_tool_result(response_empty)
         tasks_empty = payload_empty["tasks"]

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -404,16 +404,23 @@ def test_task_status_completion_metadata():
     print("Test 8: task_status exposes exit_code and completed_at for completed jobs")
     process, _ = start_mcp_process()
     try:
-        send_request(
+        start_response, _ = send_request(
             process,
-            tool_request(9, "task_start", {"unique_name": "test-task"}),
+            tool_request(9, "task_start", {"unique_name": "test-task", "wait_for_exit_seconds": 0}),
         )
+        start_payload = parse_tool_result(start_response)
+        pid = start_payload.get("pid")
+        assert_condition(isinstance(pid, int) and pid > 0, "running task should expose pid", start_payload)
+
+        # Sleep briefly to ensure the quick-exit task has finished executing
+        import time
+        time.sleep(1.0)
+
         status_response, _ = send_request(
             process,
-            tool_request(10, "task_status", {"unique_name": "test-task"}),
+            tool_request(10, "task_status", {"pid": pid}),
         )
-        payload = parse_tool_result(status_response)
-        job = find_job(payload["jobs"], "test-task")
+        job = parse_tool_result(status_response)
         assert_condition(job["state"] == "exited", "completed test-task should be exited", job)
         assert_condition(job["exit_code"] == 0, "completed test-task should expose exit_code", job)
         assert_condition(
@@ -459,9 +466,9 @@ def test_running_lifecycle_and_stop():
 
         task_status_response, _ = send_request(
             process,
-            tool_request(13, "task_status", {"unique_name": "long-running-task"}),
+            tool_request(13, "task_status", {"pid": pid}),
         )
-        task_status_job = find_job(parse_tool_result(task_status_response)["jobs"], "long-running-task", pid=pid)
+        task_status_job = parse_tool_result(task_status_response)
         assert_condition(task_status_job["state"] == "running", "task_status should report running state", task_status_job)
         assert_condition(task_status_job["exit_code"] is None, "running job should not have exit_code", task_status_job)
         assert_condition(

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -267,6 +267,34 @@ def test_list_tasks_enriched_fields():
         stop_process(process)
 
 
+def test_list_tasks_cwd():
+    print("Test 3b: list_tasks supports custom cwd argument")
+    process, _ = start_mcp_process()
+    try:
+        # Check listing with custom cwd pointing to test_project (same results as default)
+        response, _ = send_request(
+            process,
+            tool_request(31, "list_tasks", {"cwd": "/home/testuser/test_project"}),
+        )
+        payload = parse_tool_result(response)
+        tasks = payload["tasks"]
+        assert_condition(len(tasks) > 0, "custom cwd should return tasks", payload)
+        assert_condition(any(t["unique_name"] == "test-task" for t in tasks), "should find test-task in custom cwd", tasks)
+
+        # Check listing with empty directory cwd
+        response_empty, _ = send_request(
+            process,
+            tool_request(32, "list_tasks", {"cwd": "/home/testuser/.config/dela"}),
+        )
+        payload_empty = parse_tool_result(response_empty)
+        tasks_empty = payload_empty["tasks"]
+        assert_condition(len(tasks_empty) == 0, "empty cwd should return zero tasks", payload_empty)
+        print("✓ list_tasks respects custom cwd parameter")
+        return True
+    finally:
+        stop_process(process)
+
+
 def test_task_start_quick_exit():
     print("Test 4: task_start returns direct quick-exit payload")
     process, _ = start_mcp_process()
@@ -440,7 +468,7 @@ def test_running_lifecycle_and_stop():
     try:
         start_response, _ = send_request(
             process,
-            tool_request(11, "task_start", {"unique_name": "long-running-task"}),
+            tool_request(11, "task_start", {"unique_name": "long-running-task", "cwd": "/home/testuser/test_project"}),
             timeout_seconds=10,
         )
         start_payload = parse_tool_result(start_response)
@@ -455,9 +483,20 @@ def test_running_lifecycle_and_stop():
         )
 
         status_response, _ = send_request(process, tool_request(12, "status"))
-        running = parse_tool_result(status_response)["running"]
+        status_payload = parse_tool_result(status_response)
+        assert_condition(
+            status_payload.get("cwd") == "/home/testuser/test_project",
+            "status response should include top-level server cwd",
+            status_payload,
+        )
+        running = status_payload["running"]
         running_job = find_job(running, "long-running-task", pid=pid)
         assert_condition(running_job["pid"] == pid, "status should report the running pid", running_job)
+        assert_condition(
+            running_job.get("cwd") == "/home/testuser/test_project",
+            "running job should report task-specific cwd in status",
+            running_job,
+        )
         assert_condition(
             isinstance(running_job.get("elapsed_seconds"), int),
             "status should include elapsed_seconds",
@@ -470,6 +509,11 @@ def test_running_lifecycle_and_stop():
         )
         task_status_job = parse_tool_result(task_status_response)
         assert_condition(task_status_job["state"] == "running", "task_status should report running state", task_status_job)
+        assert_condition(
+            task_status_job.get("cwd") == "/home/testuser/test_project",
+            "task_status should report task-specific cwd",
+            task_status_job,
+        )
         assert_condition(task_status_job["exit_code"] is None, "running job should not have exit_code", task_status_job)
         assert_condition(
             task_status_job["completed_at"] is None,
@@ -620,6 +664,7 @@ def main():
         test_initialize_instructions,
         test_tools_list_schema,
         test_list_tasks_enriched_fields,
+        test_list_tasks_cwd,
         test_task_start_quick_exit,
         test_task_start_args_and_spaces,
         test_error_taxonomy,

--- a/tests/docker_mcp/test_mcp.py
+++ b/tests/docker_mcp/test_mcp.py
@@ -274,7 +274,7 @@ def test_list_tasks_cwd():
         # Check listing with custom cwd pointing to test_project (same results as default)
         response, _ = send_request(
             process,
-            tool_request(31, "list_tasks", {"cwd": "/home/testuser/test_project"}),
+            tool_request(31, "list_tasks", {"cwd": PROJECT_CWD}),
         )
         payload = parse_tool_result(response)
         tasks = payload["tasks"]
@@ -284,7 +284,7 @@ def test_list_tasks_cwd():
         # Check listing with empty directory cwd
         response_empty, _ = send_request(
             process,
-            tool_request(32, "list_tasks", {"cwd": "/home/testuser/test_project/assets_py"}),
+            tool_request(32, "list_tasks", {"cwd": f"{PROJECT_CWD}/assets_py"}),
         )
         payload_empty = parse_tool_result(response_empty)
         tasks_empty = payload_empty["tasks"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `cwd` support for listing and starting tasks so discovery/execution can run relative to a requested directory.
  * Updated task status to be `pid`-based, returning a single job status payload and including `cwd` in responses.

* **Bug Fixes**
  * Improved task discovery caching to reuse results only for the same resolved `cwd` within the cache window.
  * Updated task output/stop/status to return clear PID-specific “job not found” errors for nonexistent PIDs.

* **Tests**
  * Added integration coverage for `cwd`-based task listing and refreshed lifecycle assertions to use `pid` and validate returned `cwd`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->