### PR TITLE
Bump rust and alpine versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
 
       - name: Verify release metadata
         id: release_meta
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           components: rustfmt, clippy
 
       - name: Run lint
@@ -96,7 +96,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
 
       - name: Validate publish package
         run: cargo publish --dry-run --locked
@@ -134,7 +134,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           targets: ${{ matrix.target }}
 
       - name: Install Linux cross-compilation tools
@@ -242,7 +242,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
 
       - name: Check whether version is already published
         id: crates_version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
-          toolchain: 1.93.0
+          toolchain: 1.96.1
           components: rustfmt, clippy
       
       - name: Cache dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dela"
 version = "0.0.6"
-rust-version = "1.93.0"
+rust-version = "1.96.1"
 edition = "2024"
 license = "MIT"
 authors = ["Alexander Yankov"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build tests tests_integration test_unit test_noinit test_mcp test_zsh test_bash test_fish test_pwsh run install
 
 SHELL := /bin/bash
-export RUSTUP_TOOLCHAIN=1.93.0
+export RUSTUP_TOOLCHAIN=1.96.1
 
 # Default to non-verbose output
 VERBOSE ?= 0

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ $ dela init
 Alternatively, you can build and install the Rust binary directly from crates.io:
 
 ```sh
-$ cargo +1.96.1 install dela
-$ dela init
+cargo +1.96.1 install dela
+dela init
 ```
 
 The `dela init` command will:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ dela init
 Alternatively, you can build and install the Rust binary directly from crates.io:
 
 ```sh
-$ cargo +1.93.0 install dela
+$ cargo +1.96.1 install dela
 $ dela init
 ```
 

--- a/dev_docs/testing.md
+++ b/dev_docs/testing.md
@@ -40,7 +40,7 @@ The project uses a combination of unit tests and integration tests. Unit tests c
 
 Each shell type (bash, fish, zsh, pwsh) has its own Dockerfile in the `tests/docker_*/` directories. These Dockerfiles:
 
-1. **Base Environment**: All use `alpine:3.21` as the base image
+1. **Base Environment**: All use Alpine 3.24 as the base image
 2. **Package Installation**: Install shell-specific packages and common tools:
    - Shell-specific package (bash/fish/zsh/powershell)
    - Build tools (make)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.96.1"
 components = ["rustfmt", "clippy"]

--- a/tests/Dockerfile.builder
+++ b/tests/Dockerfile.builder
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # --- Stage 1: Builder ---
-FROM rust:1.93.0-alpine3.21 AS builder
+FROM rust:1.96.1-alpine3.24 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache \
@@ -35,4 +35,4 @@ COPY README.md ./
 
 # Build the project (debug mode only)
 RUN cargo build --all-features && \
-    cargo test --all-features --no-run 
+    cargo test --all-features --no-run

--- a/tests/docker_bash/Dockerfile
+++ b/tests/docker_bash/Dockerfile
@@ -11,10 +11,10 @@ RUN apk add --no-cache \
     make \
     python3 \
     uv \
-    poetry && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community go-task
+    poetry \
+    go-task
 
-# symlink go-task to task
+# Alpine names the binary go-task, while Taskfiles use the upstream task command.
 RUN ln -s /usr/bin/go-task /usr/local/bin/task
 
 # Create test user

--- a/tests/docker_bash/Dockerfile
+++ b/tests/docker_bash/Dockerfile
@@ -3,7 +3,7 @@
 FROM dela-builder AS builder
 
 # Test environment
-FROM alpine:3.21
+FROM alpine:3.24
 
 # Install minimal required packages for testing
 RUN apk add --no-cache \
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
     python3 \
     uv \
     poetry && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.21/community go-task
+    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community go-task
 
 # symlink go-task to task
 RUN ln -s /usr/bin/go-task /usr/local/bin/task

--- a/tests/docker_fish/Dockerfile
+++ b/tests/docker_fish/Dockerfile
@@ -3,7 +3,7 @@
 FROM dela-builder AS builder
 
 # Test environment
-FROM alpine:3.21
+FROM alpine:3.24
     
 # Install required packages
 RUN apk add --no-cache \
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
     python3 \
     uv \
     poetry && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.21/community go-task
+    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community go-task
 
 # symlink go-task to task
 RUN ln -s /usr/bin/go-task /usr/local/bin/task

--- a/tests/docker_fish/Dockerfile
+++ b/tests/docker_fish/Dockerfile
@@ -11,10 +11,10 @@ RUN apk add --no-cache \
     make \
     python3 \
     uv \
-    poetry && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community go-task
+    poetry \
+    go-task
 
-# symlink go-task to task
+# Alpine names the binary go-task, while Taskfiles use the upstream task command.
 RUN ln -s /usr/bin/go-task /usr/local/bin/task
 
 # Create test user

--- a/tests/docker_noinit/Dockerfile
+++ b/tests/docker_noinit/Dockerfile
@@ -17,25 +17,16 @@ RUN apk add --no-cache \
     maven \
     gradle \
     docker-cli \
-    util-linux && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community go-task
+    util-linux \
+    git \
+    go-task \
+    act
 
-# symlink go-task to task
+# Alpine names the binary go-task, while Taskfiles use the upstream task command.
 RUN ln -s /usr/bin/go-task /usr/local/bin/task
 
+# Turborepo is not packaged by Alpine, so install the pinned npm release.
 RUN npm install -g turbo@2.9.6
-
-
-# Install act (GitHub Actions runner)
-# TODO: Get act from the package manager, once it is in a non-edge alpine release.
-RUN apk add --no-cache curl git bash && \
-    mkdir -p /tmp/act-installation && \
-    cd /tmp/act-installation && \
-    curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh | bash && \
-    mv ./bin/act /usr/local/bin/ && \
-    chmod +x /usr/local/bin/act && \
-    cd / && \
-    rm -rf /tmp/act-installation
 
 # Create test user
 RUN adduser -D -s /bin/zsh testuser

--- a/tests/docker_noinit/Dockerfile
+++ b/tests/docker_noinit/Dockerfile
@@ -3,7 +3,7 @@
 FROM dela-builder AS builder
 
 # Test environment
-FROM alpine:3.21
+FROM alpine:3.24
     
 # Install required packages
 RUN apk add --no-cache \
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
     gradle \
     docker-cli \
     util-linux && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.21/community go-task
+    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community go-task
 
 # symlink go-task to task
 RUN ln -s /usr/bin/go-task /usr/local/bin/task

--- a/tests/docker_pwsh/Dockerfile
+++ b/tests/docker_pwsh/Dockerfile
@@ -3,7 +3,7 @@
 FROM dela-builder AS builder
 
 # Test environment
-FROM alpine:3.21
+FROM alpine:3.24
     
 # Install required packages
 RUN apk add --no-cache \
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
     uv \
     poetry \
     npm && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.21/community task
+    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community task
 
 # Create test user
 RUN adduser -D -s /bin/pwsh testuser

--- a/tests/docker_pwsh/Dockerfile
+++ b/tests/docker_pwsh/Dockerfile
@@ -12,8 +12,11 @@ RUN apk add --no-cache \
     python3 \
     uv \
     poetry \
-    npm && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community task
+    npm \
+    go-task
+
+# Alpine names the binary go-task, while Taskfiles use the upstream task command.
+RUN ln -s /usr/bin/go-task /usr/local/bin/task
 
 # Create test user
 RUN adduser -D -s /bin/pwsh testuser

--- a/tests/docker_unit/Dockerfile
+++ b/tests/docker_unit/Dockerfile
@@ -2,7 +2,7 @@
 FROM dela-builder AS builder
 
 # Test environment
-FROM rust:1.93.0-alpine3.21
+FROM dela-builder
 
 # Install build dependencies
 RUN apk add --no-cache \

--- a/tests/docker_zsh/Dockerfile
+++ b/tests/docker_zsh/Dockerfile
@@ -3,7 +3,7 @@
 FROM dela-builder AS builder
 
 # Test environment
-FROM alpine:3.21
+FROM alpine:3.24
     
 # Install required packages
 RUN apk add --no-cache \
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
     python3 \
     uv \
     poetry && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.21/community go-task
+    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community go-task
 
 # symlink go-task to task
 RUN ln -s /usr/bin/go-task /usr/local/bin/task

--- a/tests/docker_zsh/Dockerfile
+++ b/tests/docker_zsh/Dockerfile
@@ -11,10 +11,10 @@ RUN apk add --no-cache \
     make \
     python3 \
     uv \
-    poetry && \
-    apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.24/community go-task
+    poetry \
+    go-task
 
-# symlink go-task to task
+# Alpine names the binary go-task, while Taskfiles use the upstream task command.
 RUN ln -s /usr/bin/go-task /usr/local/bin/task
 
 # Create test user

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -39,6 +39,12 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 log "SCRIPT_DIR: ${SCRIPT_DIR}"
 log "PROJECT_ROOT: ${PROJECT_ROOT}"
 
+# Build the default builder image when run directly without one.
+if [ -z "$BUILDER_IMAGE" ] && ! docker image inspect dela-builder >/dev/null 2>&1; then
+    log "Building base builder image..."
+    docker build --platform "$DOCKER_PLATFORM" -t dela-builder -f "${SCRIPT_DIR}/Dockerfile.builder" "${PROJECT_ROOT}"
+fi
+
 # Function to run tests for a specific shell
 run_shell_tests() {
     local shell=$1
@@ -124,4 +130,4 @@ else
         log "Testing ${shell} shell integration..."
         run_shell_tests "${shell}"
     done
-fi 
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Rust version to 1.96.1 across the project.
  * Upgraded test environments to Alpine Linux 3.24.
  * Streamlined installation of the Task command in test environments.
  * Updated the unit test environment to use the project’s local builder image.
  * Improved automatic local builder image creation when needed.

* **Documentation**
  * Updated Rust setup and testing documentation to reflect the new toolchain and Alpine versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->